### PR TITLE
feat: Dockerize WordPress for Coolify Deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+Dockerfile
+README.md
+wp-config-sample.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official WordPress image with PHP 8.2 and Apache
+FROM wordpress:6.6.1-php8.2-apache
+
+# Enable Apache rewrite module for permalinks
+RUN a2enmod rewrite
+
+# Copy the .htaccess file
+COPY .htaccess /var/www/html/.htaccess
+
+# Copy the wp-content directory
+COPY wp-content /var/www/html/wp-content
+
+# Set the correct permissions for wp-content
+RUN chown -R www-data:www-data /var/www/html/wp-content
+
+# Expose port 80 for the Apache web server
+EXPOSE 80

--- a/wp-config.php
+++ b/wp-config.php
@@ -20,16 +20,16 @@
 
 // ** Database settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
-define( 'DB_NAME', 'motorlandev' );
+define( 'DB_NAME', getenv('WORDPRESS_DB_NAME') ?: 'motorlandev' );
 
 /** Database username */
-define( 'DB_USER', 'root' );
+define( 'DB_USER', getenv('WORDPRESS_DB_USER') ?: 'root' );
 
 /** Database password */
-define( 'DB_PASSWORD', '' );
+define( 'DB_PASSWORD', getenv('WORDPRESS_DB_PASSWORD') ?: '' );
 
 /** Database hostname */
-define( 'DB_HOST', 'localhost' );
+define( 'DB_HOST', getenv('WORDPRESS_DB_HOST') ?: 'localhost' );
 
 /** Database charset to use in creating database tables. */
 define( 'DB_CHARSET', 'utf8mb4' );
@@ -89,7 +89,9 @@ define( 'WP_DEBUG', false );
 
 /* Add any custom values between this line and the "stop editing" line. */
 
-
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+    $_SERVER['HTTPS'] = 'on';
+}
 
 /* That's all, stop editing! Happy publishing. */
 


### PR DESCRIPTION
This commit introduces a Dockerfile and necessary configuration changes to allow the WordPress site to be deployed on the Coolify platform.

The changes include:
- A `Dockerfile` that uses the official `wordpress:6.6.1-php8.2-apache` image, copies the `wp-content` and `.htaccess` files, and sets the correct file permissions.
- A `.dockerignore` file to exclude unnecessary files from the Docker image.
- Modifications to `wp-config.php` to:
  - Read database credentials from environment variables, which is a security best practice and required for Coolify's database integration.
  - Correctly detect HTTPS when running behind a reverse proxy, preventing mixed-content issues.