### PR TITLE
feat: Create an admin page for motor filtering

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/assets/css/admin-styles.css
+++ b/wp-content/plugins/motorlan-api-vue/assets/css/admin-styles.css
@@ -1,0 +1,66 @@
+/* Motorlan Admin Styles */
+
+#motorlan-filters-app {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    grid-gap: 40px;
+    margin-top: 20px;
+}
+
+#motorlan-filters-form {
+    background: #fff;
+    padding: 20px;
+    border: 1px solid #ccd0d4;
+    border-radius: 4px;
+}
+
+#motorlan-filters-form .form-table th {
+    font-weight: 600;
+    padding: 10px 10px 10px 0;
+}
+
+#motorlan-filters-form .form-table td {
+    padding: 5px 0;
+}
+
+#motorlan-filters-form .form-table input[type="text"],
+#motorlan-filters-form .form-table input[type="number"],
+#motorlan-filters-form .form-table select {
+    width: 100%;
+}
+
+#motorlan-filters-form .small-text {
+    width: calc(50% - 10px) !important;
+    display: inline-block;
+}
+
+#motorlan-filters-form .submit {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid #ccd0d4;
+}
+
+#motorlan-results {
+    background: #fff;
+    padding: 20px;
+    border: 1px solid #ccd0d4;
+    border-radius: 4px;
+}
+
+#motorlan-results table {
+    margin-top: 0;
+}
+
+#motorlan-results table th {
+    background: #f5f5f5;
+}
+
+#motorlan-results table td {
+    vertical-align: middle;
+}
+
+#motorlan-results table img {
+    max-width: 100px;
+    height: auto;
+    border-radius: 4px;
+}

--- a/wp-content/plugins/motorlan-api-vue/assets/js/admin-filters.js
+++ b/wp-content/plugins/motorlan-api-vue/assets/js/admin-filters.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('motorlan-filters-form');
+    const resultsContainer = document.getElementById('motorlan-results');
+
+    form.addEventListener('submit', function (event) {
+        event.preventDefault();
+
+        resultsContainer.innerHTML = '<p>Loading...</p>';
+
+        const formData = new FormData(form);
+        const params = new URLSearchParams();
+
+        for (const [key, value] of formData.entries()) {
+            if (value) {
+                params.append(key, value);
+            }
+        }
+
+        // The REST API URL is passed from WordPress using wp_localize_script
+        fetch(`${motorlan_filters_vars.api_url}?${params.toString()}`)
+            .then(response => response.json())
+            .then(motors => {
+                displayMotors(motors);
+            })
+            .catch(error => {
+                console.error('Error fetching motors:', error);
+                resultsContainer.innerHTML = '<p>Error fetching motors. Please try again.</p>';
+            });
+    });
+
+    function displayMotors(motors) {
+        if (motors.length === 0) {
+            resultsContainer.innerHTML = '<p>No motors found.</p>';
+            return;
+        }
+
+        let html = '<table class="wp-list-table widefat striped"><thead><tr>';
+        html += '<th scope="col">Image</th>';
+        html += '<th scope="col">Title</th>';
+        html += '<th scope="col">Brand</th>';
+        html += '<th scope="col">Power (kW)</th>';
+        html += '<th scope="col">Speed (rpm)</th>';
+        html += '</tr></thead><tbody>';
+
+        motors.forEach(motor => {
+            html += '<tr>';
+            const imageUrl = motor.acf.motor_image ? motor.acf.motor_image.sizes.thumbnail : '';
+            html += `<td>${imageUrl ? `<img src="${imageUrl}" width="100">` : 'No Image'}</td>`;
+            html += `<td>${motor.title}</td>`;
+            html += `<td>${motor.acf.marca || ''}</td>`;
+            html += `<td>${motor.acf.potencia || ''}</td>`;
+            html += `<td>${motor.acf.velocidad || ''}</td>`;
+            html += '</tr>';
+        });
+
+        html += '</tbody></table>';
+        resultsContainer.innerHTML = html;
+    }
+});


### PR DESCRIPTION
This change adds a new admin page to the Motorlan plugin. The new page provides a user interface for filtering and viewing the list of motors.

The new admin page can be found under the "Motorlan" menu item in the WordPress admin dashboard.

The page includes the following features:
- Filtering by brand, power, speed, country, power type, and servomotors.
- A modern and clean design for the filter form and the results table.
- Asynchronous filtering with JavaScript, which provides a fast and smooth user experience.