### PR TITLE
fix(fake-api): Create missing mock API handler files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/app-bar-search/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/app-bar-search/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppBarSearch = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/academy/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/academy/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsAcademy = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/chat/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/chat/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsChat = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/ecommerce/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/ecommerce/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsEcommerce = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/email/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/email/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsEmail = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/invoice/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/invoice/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsInvoice = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/logistics/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/logistics/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppLogistics = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/permission/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/permission/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsPermission = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/users/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/apps/users/index.ts
@@ -1,0 +1,1 @@
+export const handlerAppsUsers = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/auth/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/auth/index.ts
@@ -1,0 +1,1 @@
+export const handlerAuth = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/dashboard/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/dashboard/index.ts
@@ -1,0 +1,1 @@
+export const handlerDashboard = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/datatable/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/datatable/index.ts
@@ -1,0 +1,1 @@
+export const handlerPagesDatatable = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/faq/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/faq/index.ts
@@ -1,0 +1,1 @@
+export const handlerPagesFaq = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/help-center/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/help-center/index.ts
@@ -1,0 +1,1 @@
+export const handlerPagesHelpCenter = []

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/profile/index.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/fake-api/handlers/pages/profile/index.ts
@@ -1,0 +1,1 @@
+export const handlerPagesProfile = []


### PR DESCRIPTION
Resolves a Vite compilation error "Failed to resolve import" by creating the entire missing directory structure and placeholder files for the mock API handlers under `src/plugins/fake-api/handlers/`.

The alias `@db` pointed to a non-existent `handlers` directory. This change adds the directory and all the handler files referenced in `src/plugins/fake-api/index.ts`, allowing the application to build successfully. Each handler is created as a placeholder exporting an empty array.