### PR TITLE
fix(login): Render HTML in error messages

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/login.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/login.vue
@@ -170,7 +170,7 @@ const onSubmit = () => {
             variant="tonal"
             class="mb-4"
           >
-            {{ genericError }}
+            <div v-html="genericError" />
           </VAlert>
 
           <VForm


### PR DESCRIPTION
This commit fixes an issue where HTML error messages returned from the WordPress API were being displayed as plain text in the login form.

The `VAlert` component in `login.vue` has been updated to use the `v-html` directive. This ensures that the error messages are rendered correctly as HTML, preserving their original formatting and improving the user experience.