### PR TITLE
fix(login): Use form-urlencoded for login request

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/login.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/login.vue
@@ -49,12 +49,16 @@ const login = async () => {
     errors.value = { username: undefined, password: undefined }
     genericError.value = null
 
+    const body = new URLSearchParams()
+    body.append('username', credentials.value.username)
+    body.append('password', credentials.value.password)
+
     const res = await api('/wp-json/jwt-auth/v1/token', {
       method: 'POST',
-      body: {
-        username: credentials.value.username,
-        password: credentials.value.password,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
+      body,
       onResponseError({ response }) {
         if (response._data && response._data.errors) {
           errors.value = response._data.errors


### PR DESCRIPTION
This commit changes the login request's content type from `application/json` to `application/x-w-form-urlencoded`.

Some server configurations or WordPress plugins can have difficulty parsing a JSON request body correctly, leading to authentication errors like `[jwt_auth] invalid_email`.

By sending the credentials as `form-urlencoded`, we ensure that the backend can reliably read the `username` and `password` from the POST request, resolving the issue and making the login process more robust.