### PR TITLE
feat: Change primary color to #ff1e0a

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/@core/libs/apex-chart/apexCharConfig.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/@core/libs/apex-chart/apexCharConfig.ts
@@ -14,7 +14,7 @@ const colorVariables = (themeColors: ThemeInstance['themes']['value']['colors'])
 export const getScatterChartConfig = (themeColors: ThemeInstance['themes']['value']['colors']) => {
   const scatterColors = {
     series1: '#ff9f43',
-    series2: '#7367f0',
+    series2: '#ff1e0a',
     series3: '#28c76f',
   }
 
@@ -231,7 +231,7 @@ export const getRadialBarChartConfig = (themeColors: ThemeInstance['themes']['va
     series1: '#fdd835',
     series2: '#32baff',
     series3: '#00d4bd',
-    series4: '#7367f0',
+    series4: '#ff1e0a',
     series5: '#FFA1A1',
   }
 
@@ -599,7 +599,7 @@ export const getHeatMapChartConfig = (themeColors: ThemeInstance['themes']['valu
             { to: 30, from: 21, name: '20-30', color: '#9d95f5' },
             { to: 40, from: 31, name: '30-40', color: '#8f85f3' },
             { to: 50, from: 41, name: '40-50', color: '#8176f2' },
-            { to: 60, from: 51, name: '50-60', color: '#7367f0' },
+            { to: 60, from: 51, name: '50-60', color: '#ff1e0a' },
           ],
         },
       },

--- a/wp-content/plugins/motorlan-api-vue/app/src/views/apps/logistics/LogisticsShipmentStatistics.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/views/apps/logistics/LogisticsShipmentStatistics.vue
@@ -3,7 +3,7 @@ const chartColors = {
   line: {
     series1: '#FFB400',
     series2: '#9055FD',
-    series3: '#7367f029',
+    series3: '#ff1e0a29',
   },
 }
 


### PR DESCRIPTION
This commit changes the primary color of the application from `rgb(115,103,240)` to `#ff1e0a`. The color was updated in the following files:
- `wp-content/plugins/motorlan-api-vue/app/src/@core/libs/apex-chart/apexCharConfig.ts`
- `wp-content/plugins/motorlan-api-vue/app/src/views/apps/logistics/LogisticsShipmentStatistics.vue`