### PR TITLE
Fix: Resolve infinite reload loop and handle session expiry

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/1.router/guards.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/1.router/guards.ts
@@ -16,7 +16,7 @@ export const setupGuards = (router: _RouterTyped<RouteNamedMap & { [key: string]
      * Check if user is logged in by checking if token & user data exists in local storage
      * Feel free to update this logic to suit your needs
      */
-    const isLoggedIn = !!(useCookie('userData').value && useCookie('accessToken').value)
+    const isLoggedIn = !!useCookie('userData').value
 
     /*
       If user is logged in and is trying to access login like page, redirect to home

--- a/wp-content/plugins/motorlan-api-vue/app/src/services/api.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/services/api.ts
@@ -16,10 +16,15 @@ const getToken = () => {
   return cookies.accessToken || null
 }
 
+// Helper function to clear a cookie by name
+const clearCookie = (name: string) => {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
+}
+
 const api = ofetch.create({
   baseURL,
   headers: {
-    'Content-Type': 'application/json', 
+    'Content-Type': 'application/json',
   },
   onRequest: ({ options }) => {
     const token = getToken()
@@ -31,6 +36,20 @@ const api = ofetch.create({
       headers.set('Authorization', `Bearer ${token}`)
 
     options.headers = headers
+  },
+  onResponseError: ({ response }) => {
+    if (response.status === 401) {
+      // Clear all user-related cookies
+      clearCookie('userData')
+      clearCookie('accessToken')
+      clearCookie('userAbilityRules')
+
+      // We are using hard navigation here as router instance is not available here
+      // You can also use create a plugin to navigate to login page
+      // e.g. create a new plugin that exposes a function to navigate to login page
+      // and then call that function here
+      window.location.href = '/login'
+    }
   },
 })
 


### PR DESCRIPTION
This commit addresses an issue where the application would enter an infinite loading state after a user logs in and reloads the page.

The root cause was a faulty client-side authentication check in the Vue Router navigation guard. The guard was checking for an `accessToken` cookie that was not reliably accessible on page load, causing the application to believe the user was logged out and triggering a redirect loop.

The fix involves two main changes:

1.  **Modified Route Guard:** The navigation guard in `app/src/plugins/1.router/guards.ts` has been updated to only check for the presence of the `userData` cookie. This is a more reliable way to determine if a user session exists on the client-side.

2.  **Global 401 Error Handler:** A global `onResponseError` interceptor has been added to the API service in `app/src/services/api.ts`. This handler catches 401 Unauthorized responses from the API, which occur when a session is invalid or expired. Upon catching a 401 error, it clears all session-related cookies and redirects the user to the login page, ensuring a clean logout and preventing the application from getting stuck in a broken state.