### PR TITLE
refactor: Remove acf.titulo_entrada and use post title

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
@@ -10,7 +10,6 @@ const motorData = ref({
   title: '',
   status: 'publish',
   acf: {
-    titulo_entrada: '',
     marca: null,
     tipo_o_referencia: '',
     motor_image: null,
@@ -147,7 +146,7 @@ const content = ref(
               >
                 <AppTextField
                   v-model="motorData.title"
-                  label="Título entrada"
+                  label="Título de la publicación"
                   placeholder="Título"
                 />
               </VCol>

--- a/wp-content/plugins/motorlan-api-vue/includes/acf-setup.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/acf-setup.php
@@ -17,12 +17,6 @@ acf_add_local_field_group(array(
 	'title' => 'Detalles del Motor',
 	'fields' => array(
 		array(
-			'key' => 'field_6643d3c3b0340',
-			'label' => 'Título entrada',
-			'name' => 'titulo_entrada',
-			'type' => 'text',
-		),
-		array(
 			'key' => 'field_6643d3c3b0341',
 			'label' => 'Marca',
 			'name' => 'marca',

--- a/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
@@ -38,7 +38,7 @@ function motorlan_get_motors_callback( $request ) {
 
     // Define the list of fields that can be used for filtering.
     $filterable_fields = [
-        'titulo_entrada', 'marca', 'tipo_o_referencia', 'potencia', 'velocidad', 'par_nominal', 'voltaje', 'intensidad',
+        'marca', 'tipo_o_referencia', 'potencia', 'velocidad', 'par_nominal', 'voltaje', 'intensidad',
         'pais', 'provincia', 'estado_del_articulo', 'posibilidad_de_alquiler', 'tipo_de_alimentacion',
         'servomotores', 'regulacion_electronica_drivers', 'precio_de_venta', 'precio_negociable'
     ];
@@ -88,7 +88,7 @@ function motorlan_get_motors_callback( $request ) {
             if ( function_exists('get_field') ) {
                 $acf_fields = [
 
-                    'titulo_entrada', 'marca', 'tipo_o_referencia','estado_del_articulo','descripcion',
+                    'marca', 'tipo_o_referencia','estado_del_articulo','descripcion',
                     'precio_de_venta',
                     'publicar_acf'
                 ];


### PR DESCRIPTION
Removes the `titulo_entrada` Advanced Custom Field from the "motor" post type and refactors the code to use the standard WordPress post title instead.

- Removes the ACF field definition in `acf-setup.php`.
- Updates the REST API in `motor-routes.php` to no longer filter by or return the `titulo_entrada` field.
- Modifies the Vue.js frontend in `index.vue` to use the standard post title and removes the unused `titulo_entrada` from the data model.