### PR TITLE
feat: Add pagination data to motorlan_get_motors_callback response body

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
@@ -105,10 +105,24 @@ function motorlan_get_motors_callback( $request ) {
         wp_reset_postdata();
     }
 
-    // Create the response object.
-    $response = new WP_REST_Response( $motors_data, 200 );
+    // Pagination data.
+    $pagination = array(
+        'total'     => (int) $query->found_posts,
+        'totalPages' => (int) $query->max_num_pages,
+        'currentPage'    => (int) $page,
+        'perPage'   => (int) $per_page,
+    );
 
-    // Add pagination headers for client-side rendering.
+    // Prepare the data for the response.
+    $response_data = array(
+        'motors'      => $motors_data,
+        'pagination' => $pagination,
+    );
+
+    // Create the response object.
+    $response = new WP_REST_Response( $response_data, 200 );
+
+    // Add pagination headers for client-side rendering (optional, but good practice).
     $response->header( 'X-WP-Total', $query->found_posts );
     $response->header( 'X-WP-TotalPages', $query->max_num_pages );
 


### PR DESCRIPTION
The pagination information (total items, total pages, current page, and items per page) is now included in the body of the API response for the `motorlan_get_motors_callback` function. This makes it easier for clients to handle pagination without relying on response headers.