### PR TITLE
feat: Add UUID to Motor custom post type

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
@@ -60,7 +60,7 @@ function motorlan_get_motors_callback( $request ) {
     $filterable_fields = [
         'marca', 'tipo_o_referencia', 'potencia', 'velocidad', 'par_nominal', 'voltaje', 'intensidad',
         'pais', 'provincia', 'estado_del_articulo', 'posibilidad_de_alquiler', 'tipo_de_alimentacion',
-        'servomotores', 'regulacion_electronica_drivers', 'precio_de_venta', 'precio_negociable'
+        'servomotores', 'regulacion_electronica_drivers', 'precio_de_venta', 'precio_negociable', 'uuid'
     ];
 
     // Build the meta_query dynamically based on request parameters.
@@ -96,6 +96,7 @@ function motorlan_get_motors_callback( $request ) {
 
             $motor_item = array(
                 'id'           => $post_id,
+                'uuid'         => get_post_meta( $post_id, 'uuid', true ),
                 'title'        => get_the_title(),
                 'slug'         => get_post_field( 'post_name', $post_id ),
                 'status'       => get_post_status( $post_id ),

--- a/wp-content/plugins/motorlan-api-vue/includes/cpt-setup.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/cpt-setup.php
@@ -112,3 +112,25 @@ function motorlan_register_taxonomies() {
     register_taxonomy( 'marca', array( 'motor' ), $args_marca );
 }
 add_action( 'init', 'motorlan_register_taxonomies', 0 );
+
+/**
+ * Add a UUID to the motor post type if it doesn't have one.
+ *
+ * @param int $post_id The post ID.
+ */
+function motorlan_add_uuid_to_motor( $post_id ) {
+    // If this is just a revision, don't send the email.
+    if ( wp_is_post_revision( $post_id ) ) {
+        return;
+    }
+
+    // Check if the 'uuid' meta key exists and is not empty.
+    $uuid = get_post_meta( $post_id, 'uuid', true );
+    if ( empty( $uuid ) ) {
+        // Generate a UUID.
+        $uuid = wp_generate_uuid4();
+        // Add the UUID as a custom field.
+        update_post_meta( $post_id, 'uuid', $uuid );
+    }
+}
+add_action( 'save_post_motor', 'motorlan_add_uuid_to_motor' );


### PR DESCRIPTION
- Adds a UUID to each motor when it's created or saved.
- Includes the UUID in the motor API response.
- Allows filtering motors by UUID in the API.