### PR TITLE
Fix: Handle potentially invalid data in motor list

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/list/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/list/index.vue
@@ -132,7 +132,7 @@ const { data: motorsData, execute: fetchMotors } = await useApi<any>(createUrl('
 
 ))
 
-const motors = computed((): Motor[] => (motorsData.value?.data || []).filter(Boolean))
+const motors = computed((): Motor[] => (motorsData.value?.data || []).filter((motor: any) => motor && motor.id))
 const totalMotors = computed(() => motorsData.value?.pagination.total || 0)
 
 const deleteMotor = async (id: number) => {


### PR DESCRIPTION
The motor list component was experiencing a TypeError when rendering the data table. This was due to the `motors` computed property not sufficiently filtering the data returned from the API. The original `.filter(Boolean)` could allow truthy but invalid data (like an empty object) to pass through, leading to an error when the template tried to access properties on a malformed item.

The filter has been updated to `(motor: any) => motor && motor.id`, which ensures that only objects with an ID are included in the `motors` array. This is a more robust way of validating the data and prevents the rendering error.