### PR TITLE
fix: Add CORS headers to allow API requests

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
+++ b/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
@@ -27,3 +27,18 @@ require_once MOTORLAN_API_VUE_PATH . 'includes/api/motor-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/admin-mods.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/vue-app-setup.php';
 
+/**
+ * Add CORS headers to the REST API.
+ */
+function motorlan_add_cors_headers() {
+    header( 'Access-Control-Allow-Origin: *' );
+    header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
+    header( 'Access-Control-Allow-Headers: Content-Type, X-Requested-With, X-WP-Nonce, Authorization' );
+    header( 'Access-Control-Allow-Credentials: true' );
+
+    if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
+        status_header( 200 );
+        exit();
+    }
+}
+add_action( 'rest_api_init', 'motorlan_add_cors_headers', 15 );


### PR DESCRIPTION
This commit resolves a Cross-Origin Resource Sharing (CORS) issue that blocked requests from the frontend application to the backend REST API.

A new function, `motorlan_add_cors_headers`, has been added to `motorlan-api-vue.php`. This function hooks into `rest_api_init` to send the appropriate CORS headers with every API response, ensuring that the browser allows the cross-origin requests.