### PR TITLE
Refactor the REST API route registration in `includes/api/motor-route…

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
@@ -43,20 +43,20 @@ function motorlan_register_motor_rest_routes() {
         'permission_callback' => '__return_true',
     ) );
 
-    // Route for getting a single motor by UUID
+    // Route for getting and updating a single motor by UUID
     register_rest_route($namespace, '/motors/uuid/(?P<uuid>[a-zA-Z0-9-]+)', array(
-        'methods' => 'GET',
-        'callback' => 'motorlan_get_motor_by_uuid',
-        'permission_callback' => '__return_true'
-    ));
-
-    // Route for updating a motor by UUID
-    register_rest_route($namespace, '/motors/uuid/(?P<uuid>[a-zA-Z0-9-]+)', array(
-        'methods' => 'POST',
-        'callback' => 'motorlan_update_motor_by_uuid',
-        'permission_callback' => function () {
-            return current_user_can('edit_posts');
-        }
+        array(
+            'methods' => 'GET',
+            'callback' => 'motorlan_get_motor_by_uuid',
+            'permission_callback' => '__return_true'
+        ),
+        array(
+            'methods' => 'POST',
+            'callback' => 'motorlan_update_motor_by_uuid',
+            'permission_callback' => function () {
+                return current_user_can('edit_posts');
+            }
+        ),
     ));
 
     // Route for deleting a motor by ID


### PR DESCRIPTION
…s.php` to follow WordPress best practices.

The user was reporting a `rest_no_route` error for the `/motors/{id}/duplicate` endpoint. Upon investigation, the route for duplication was found to be already registered. However, another route, for `/motors/uuid/{uuid}`, was being registered improperly, with two separate calls to `register_rest_route` for the same path with different HTTP methods.

While WordPress is supposed to merge these, it is not the recommended way to register routes and can lead to unexpected behavior in the REST API router.

This change refactors the registration for the `/motors/uuid/{uuid}` route to use a single `register_rest_route` call with an array of endpoints, as recommended by the WordPress documentation. This is expected to resolve the instability in the router and fix the `rest_no_route` error for the duplicate endpoint.