### PR TITLE
feat: Add category selection to motor forms

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
@@ -9,6 +9,7 @@ const motorId = Number(route.params.id)
 const motorData = ref({
   title: '',
   status: 'publish',
+  categories: [],
   acf: {
     marca: null,
     tipo_o_referencia: '',
@@ -36,11 +37,19 @@ const motorData = ref({
 })
 
 const marcas = ref([])
+const categories = ref([])
 
 useApi('/wp-json/wp/v2/marca').then(response => {
   marcas.value = response.data.value.map(marca => ({
     title: marca.name,
     value: marca.id,
+  }))
+})
+
+useApi('/motorlan/v1/motor-categories').then(response => {
+  categories.value = response.data.value.map(category => ({
+    title: category.name,
+    value: category.term_id,
   }))
 })
 
@@ -174,6 +183,17 @@ const content = ref(
                   v-model="motorData.acf.marca"
                   label="Marca"
                   :items="marcas"
+                />
+              </VCol>
+              <VCol
+                cols="12"
+                md="6"
+              >
+                <AppSelect
+                  v-model="motorData.categories"
+                  label="Categoría"
+                  :items="categories"
+                  multiple
                 />
               </VCol>
 

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
@@ -10,6 +10,7 @@ const motorUuid = route.params.uuid as string
 
 const motorData = ref({
   title: '',
+  categories: [],
   acf: {
     marca: null,
     tipo_o_referencia: '',
@@ -38,6 +39,7 @@ const motorImageFile = ref([])
 const motorGalleryFiles = ref([])
 
 const marcas = ref([])
+const categories = ref([])
 const form = ref(null)
 const isFormValid = ref(false)
 
@@ -46,6 +48,13 @@ useApi('/wp-json/motorlan/v1/marcas').then(response => {
   marcas.value = response.data.value.map(marca => ({
     title: marca.name,
     value: marca.id,
+  }))
+})
+
+useApi('/motorlan/v1/motor-categories').then(response => {
+  categories.value = response.data.value.map(category => ({
+    title: category.name,
+    value: category.term_id,
   }))
 })
 
@@ -58,6 +67,10 @@ onMounted(async () => {
       // If marca is an object, extract the ID for the v-model
       if (post.acf.marca && typeof post.acf.marca === 'object') {
         post.acf.marca = post.acf.marca.id
+      }
+
+      if (post.categories) {
+        motorData.value.categories = post.categories.map(cat => cat.id)
       }
 
       motorData.value = {
@@ -231,6 +244,17 @@ const updateMotor = async () => {
                   label="Marca"
                   :items="marcas"
                   :rules="[requiredValidator]"
+                />
+              </VCol>
+              <VCol
+                cols="12"
+                md="6"
+              >
+                <AppSelect
+                  v-model="motorData.categories"
+                  label="Categoría"
+                  :items="categories"
+                  multiple
                 />
               </VCol>
 

--- a/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
@@ -237,6 +237,11 @@ function motorlan_update_motor_by_uuid(WP_REST_Request $request) {
         wp_update_post(array('ID' => $post_id, 'post_title' => sanitize_text_field($params['title'])));
     }
 
+    // Update post categories
+    if (isset($params['categories'])) {
+        wp_set_post_terms($post_id, $params['categories'], 'categoria', false);
+    }
+
     // Update ACF fields
     if (isset($params['acf']) && is_array($params['acf'])) {
         foreach ($params['acf'] as $key => $value) {


### PR DESCRIPTION
- Adds a category selector to the 'create motor' and 'edit motor' pages.
- The selector allows for multiple categories to be selected.
- Updates the backend to handle saving the selected categories.