### PR TITLE
fix: Correctly display category names in select component

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
@@ -193,6 +193,8 @@ const content = ref(
                   v-model="motorData.categories"
                   label="Categoría"
                   :items="categories"
+                  item-title="title"
+                  item-value="value"
                   multiple
                 />
               </VCol>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
@@ -254,6 +254,8 @@ const updateMotor = async () => {
                   v-model="motorData.categories"
                   label="Categoría"
                   :items="categories"
+                  item-title="title"
+                  item-value="value"
                   multiple
                 />
               </VCol>


### PR DESCRIPTION
The category select component was displaying `[object Object]` instead of the category name.

This was fixed by adding the `item-title` and `item-value` props to the `AppSelect` component in both the 'create motor' and 'edit motor' pages.