### PR TITLE
fix: Correct brand selection in motor edit form

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
@@ -214,17 +214,16 @@ const formattedCategories = computed({
 })
 
 const formattedMarca = computed({
-  get () {
-    console.log(motorData.value.marca)
-    if (Array.isArray(motorData.value.marca))
-      return motorData.value.marca.map(cat => (typeof cat === 'object' ? cat.id : cat))
+  get() {
+    const marca = motorData.value.acf.marca
+    if (marca && typeof marca === 'object')
+      return marca.id
 
-    return []
+    return marca
   },
-
-  set (newValue) {
-    motorData.value.marca = newValue
-  }
+  set(newValue) {
+    motorData.value.acf.marca = newValue
+  },
 })
 </script>
 


### PR DESCRIPTION
The `formattedMarca` computed property was incorrectly accessing `motorData.value.marca` instead of `motorData.value.acf.marca`, and was treating the value as an array instead of a single object. This caused the brand field to be invisible and unselectable.

This commit corrects the computed property to use the correct data source (`motorData.value.acf.marca`) and properly handle the brand object, which can be an object with an `id` or just the `id` itself. This resolves the issue and allows the brand to be displayed and selected correctly.