### PR TITLE
Fix(motors): Enable form button and validate on submit

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
@@ -41,7 +41,6 @@ const motorGalleryFiles = ref([])
 const marcas = ref([])
 const categories = ref([])
 const form = ref(null)
-const isFormValid = ref(false)
 
 onMounted(async () => {
   try {
@@ -215,7 +214,6 @@ const formattedMarca = computed({
   <div>
     <VForm
       ref="form"
-      v-model="isFormValid"
       @submit.prevent="updateMotor"
     >
       <div class="d-flex flex-wrap justify-start justify-sm-space-between gap-y-4 gap-x-6 mb-6">
@@ -232,9 +230,7 @@ const formattedMarca = computed({
           >
             Discard
           </VBtn>
-          <VBtn
-            type="submit"
-          >
+          <VBtn type="submit">
             Update Motor
           </VBtn>
         </div>


### PR DESCRIPTION
The form validation was not being updated correctly, which caused the submit button to be disabled.

This change makes the button always enabled.

The existing logic already contains functionality to validate the form on submit and show an alert to the user if validation fails, so no changes were needed there.