### PR TITLE
fix: Resolve runtime error and i18n warnings on Motores page

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
@@ -1,6 +1,6 @@
 export default [
   {
-    title: 'Tienda de Motores',
+    title: 'Motors Shop',
     to: { name: 'motores' },
     icon: { icon: 'tabler-shopping-cart' },
   },

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/motores.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/motores.vue
@@ -215,8 +215,9 @@ const handleFilterSearch = () => {
             </div>
           </VCardText>
           <VCardActions>
-            <!-- Replace with actual single motor page later -->
-            <VBtn :to="{ name: 'index' }">
+              <!-- The :to prop is temporarily removed to prevent a router crash. -->
+              <!-- A separate task will be needed to create the single motor page and re-enable this link. -->
+              <VBtn>
               Ver Detalles
             </VBtn>
           </VCardActions>

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/es.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/es.json
@@ -1,4 +1,5 @@
 {
+  "Motors Shop": "Tienda de Motores",
   "UI Elements": "UI Elements",
   "Forms & Tables": "Forms & Tables",
   "Pages": "Pages",


### PR DESCRIPTION
This commit addresses two issues found during testing:
1.  A critical runtime error (`Cannot read properties of undefined (reading 'startsWith')`) caused by a faulty `:to` prop on the "Ver Detalles" button. The link has been temporarily disabled until a single motor page is implemented.
2.  Internationalization (i18n) warnings related to missing translation keys for the navigation menu. The title has been converted to a proper i18n key and added to the `es.json` locale file.