### PR TITLE
feat: Add 'My Account' section with purchases, questions, opinions, a…

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
@@ -38,4 +38,14 @@ export default [
       { title: 'View', to: { name: 'apps-user-view-id', params: { id: 21 } } },
     ],
   },
+  {
+    title: 'My Account',
+    icon: { icon: 'tabler-user-circle' },
+    children: [
+      { title: 'Purchases', to: '/apps/my-account/purchases' },
+      { title: 'Questions', to: '/apps/my-account/questions' },
+      { title: 'Opinions', to: '/apps/my-account/opinions' },
+      { title: 'Favorites', to: '/apps/my-account/favorites' },
+    ],
+  },
 ]

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+const route = useRoute()
+
+const tabs = [
+  { title: 'Compras', to: '/apps/my-account/purchases' },
+  { title: 'Preguntas', to: '/apps/my-account/questions' },
+  { title: 'Opiniones', to: '/apps/my-account/opinions' },
+  { title: 'Favoritos', to: '/apps/my-account/favorites' },
+]
+</script>
+
+<template>
+  <div>
+    <VTabs
+      :model-value="route.path"
+      class="v-tabs-pill"
+    >
+      <VTab
+        v-for="tab in tabs"
+        :key="tab.to"
+        :to="tab.to"
+        :value="tab.to"
+      >
+        {{ tab.title }}
+      </VTab>
+    </VTabs>
+
+    <VWindow
+      :model-value="route.path"
+      class="mt-6"
+    >
+      <VWindowItem
+        v-for="tab in tabs"
+        :key="tab.to"
+        :value="tab.to"
+      >
+        <NuxtPage />
+      </VWindowItem>
+    </VWindow>
+  </div>
+</template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/favorites.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/favorites.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { useUser } from '~/composables/useUser'
+
+const { user } = useUser()
+
+const { data: favorites, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/favorites'))
+
+const headers = [
+  { title: 'Motor', key: 'motor.title' },
+]
+</script>
+
+<template>
+  <VCard>
+    <VCardTitle>Mis Favoritos</VCardTitle>
+    <VCardText>
+      <VDataTable
+        :headers="headers"
+        :items="favorites"
+        :loading="pending"
+        class="elevation-1"
+      >
+        <template #item.motor.title="{ item }">
+          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
+            {{ item.raw.motor.title }}
+          </NuxtLink>
+        </template>
+        <template #loading>
+          <VSkeletonLoader type="table-row@10" />
+        </template>
+        <template #no-data>
+          <p class="text-center">
+            No tienes motores favoritos.
+          </p>
+        </template>
+      </VDataTable>
+    </VCardText>
+  </VCard>
+</template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/opinions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/opinions.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { useUser } from '~/composables/useUser'
+
+const { user } = useUser()
+
+const { data: opinions, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/opinions'))
+
+const headers = [
+  { title: 'Motor', key: 'motor.title' },
+  { title: 'Valoración', key: 'valoracion' },
+  { title: 'Comentario', key: 'comentario' },
+]
+</script>
+
+<template>
+  <VCard>
+    <VCardTitle>Mis Opiniones</VCardTitle>
+    <VCardText>
+      <VDataTable
+        :headers="headers"
+        :items="opinions"
+        :loading="pending"
+        class="elevation-1"
+      >
+        <template #item.motor.title="{ item }">
+          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
+            {{ item.raw.motor.title }}
+          </NuxtLink>
+        </template>
+        <template #item.valoracion="{ item }">
+          <VRating
+            :model-value="item.raw.valoracion"
+            readonly
+            dense
+            size="small"
+          />
+        </template>
+        <template #loading>
+          <VSkeletonLoader type="table-row@10" />
+        </template>
+        <template #no-data>
+          <p class="text-center">
+            No has realizado ninguna opinión.
+          </p>
+        </template>
+      </VDataTable>
+    </VCardText>
+  </VCard>
+</template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/purchases.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/purchases.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useUser } from '~/composables/useUser'
+
+const { user } = useUser()
+
+const { data: purchases, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/purchases'))
+
+const headers = [
+  { title: 'Motor', key: 'motor.title' },
+  { title: 'Fecha de Compra', key: 'fecha_compra' },
+]
+</script>
+
+<template>
+  <VCard>
+    <VCardTitle>Mis Compras</VCardTitle>
+    <VCardText>
+      <VDataTable
+        :headers="headers"
+        :items="purchases"
+        :loading="pending"
+        class="elevation-1"
+      >
+        <template #item.motor.title="{ item }">
+          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
+            {{ item.raw.motor.title }}
+          </NuxtLink>
+        </template>
+        <template #loading>
+          <VSkeletonLoader type="table-row@10" />
+        </template>
+        <template #no-data>
+          <p class="text-center">
+            No has realizado ninguna compra.
+          </p>
+        </template>
+      </VDataTable>
+    </VCardText>
+  </VCard>
+</template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/questions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/questions.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { useUser } from '~/composables/useUser'
+
+const { user } = useUser()
+
+const { data: questions, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/questions'))
+
+const headers = [
+  { title: 'Motor', key: 'motor.title' },
+  { title: 'Pregunta', key: 'pregunta' },
+  { title: 'Respuesta', key: 'respuesta' },
+]
+</script>
+
+<template>
+  <VCard>
+    <VCardTitle>Mis Preguntas</VCardTitle>
+    <VCardText>
+      <VDataTable
+        :headers="headers"
+        :items="questions"
+        :loading="pending"
+        class="elevation-1"
+      >
+        <template #item.motor.title="{ item }">
+          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
+            {{ item.raw.motor.title }}
+          </NuxtLink>
+        </template>
+        <template #loading>
+          <VSkeletonLoader type="table-row@10" />
+        </template>
+        <template #no-data>
+          <p class="text-center">
+            No has realizado ninguna pregunta.
+          </p>
+        </template>
+      </VDataTable>
+    </VCardText>
+  </VCard>
+</template>

--- a/wp-content/plugins/motorlan-api-vue/includes/acf-setup-purchases.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/acf-setup-purchases.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Setup for ACF Field Groups for Purchases, Questions, and Opinions.
+ *
+ * @package motorlan-api-vue
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+if( function_exists('acf_add_local_field_group') ):
+
+// Field group for "Compra"
+acf_add_local_field_group(array(
+    'key' => 'group_compras',
+    'title' => 'Detalles de la Compra',
+    'fields' => array(
+        array(
+            'key' => 'field_compra_usuario',
+            'label' => 'Usuario',
+            'name' => 'usuario',
+            'type' => 'user',
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_compra_motor',
+            'label' => 'Motor',
+            'name' => 'motor',
+            'type' => 'post_object',
+            'post_type' => array(
+                0 => 'motor',
+            ),
+            'allow_null' => 0,
+            'multiple' => 0,
+            'return_format' => 'object',
+            'ui' => 1,
+        ),
+        array(
+            'key' => 'field_compra_fecha',
+            'label' => 'Fecha de Compra',
+            'name' => 'fecha_compra',
+            'type' => 'date_picker',
+            'display_format' => 'd/m/Y',
+            'return_format' => 'd/m/Y',
+            'first_day' => 1,
+        ),
+    ),
+    'location' => array(
+        array(
+            array(
+                'param' => 'post_type',
+                'operator' => '==',
+                'value' => 'compra',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+));
+
+// Field group for "Pregunta"
+acf_add_local_field_group(array(
+    'key' => 'group_preguntas',
+    'title' => 'Detalles de la Pregunta',
+    'fields' => array(
+        array(
+            'key' => 'field_pregunta_usuario',
+            'label' => 'Usuario',
+            'name' => 'usuario',
+            'type' => 'user',
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_pregunta_motor',
+            'label' => 'Motor',
+            'name' => 'motor',
+            'type' => 'post_object',
+            'post_type' => array(
+                0 => 'motor',
+            ),
+            'allow_null' => 0,
+            'multiple' => 0,
+            'return_format' => 'object',
+            'ui' => 1,
+        ),
+        array(
+            'key' => 'field_pregunta_pregunta',
+            'label' => 'Pregunta',
+            'name' => 'pregunta',
+            'type' => 'textarea',
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_pregunta_respuesta',
+            'label' => 'Respuesta',
+            'name' => 'respuesta',
+            'type' => 'textarea',
+        ),
+    ),
+    'location' => array(
+        array(
+            array(
+                'param' => 'post_type',
+                'operator' => '==',
+                'value' => 'pregunta',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+));
+
+// Field group for "Opinion"
+acf_add_local_field_group(array(
+    'key' => 'group_opiniones',
+    'title' => 'Detalles de la Opinión',
+    'fields' => array(
+        array(
+            'key' => 'field_opinion_usuario',
+            'label' => 'Usuario',
+            'name' => 'usuario',
+            'type' => 'user',
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_opinion_motor',
+            'label' => 'Motor',
+            'name' => 'motor',
+            'type' => 'post_object',
+            'post_type' => array(
+                0 => 'motor',
+            ),
+            'allow_null' => 0,
+            'multiple' => 0,
+            'return_format' => 'object',
+            'ui' => 1,
+        ),
+        array(
+            'key' => 'field_opinion_valoracion',
+            'label' => 'Valoración',
+            'name' => 'valoracion',
+            'type' => 'range',
+            'min' => 1,
+            'max' => 5,
+            'step' => 1,
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_opinion_comentario',
+            'label' => 'Comentario',
+            'name' => 'comentario',
+            'type' => 'textarea',
+            'required' => 1,
+        ),
+    ),
+    'location' => array(
+        array(
+            array(
+                'param' => 'post_type',
+                'operator' => '==',
+                'value' => 'opinion',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+));
+
+endif;

--- a/wp-content/plugins/motorlan-api-vue/includes/api/my-account-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/my-account-routes.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Setup for My Account REST API Routes.
+ *
+ * @package motorlan-api-vue
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Register custom REST API routes for my account.
+ */
+function motorlan_register_my_account_rest_routes() {
+    $namespace = 'motorlan/v1';
+
+    // Route for getting current user's purchases
+    register_rest_route( $namespace, '/my-account/purchases', array(
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'motorlan_get_my_purchases_callback',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        }
+    ) );
+
+    // Route for getting current user's questions
+    register_rest_route( $namespace, '/my-account/questions', array(
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'motorlan_get_my_questions_callback',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        }
+    ) );
+
+    // Route for getting current user's opinions
+    register_rest_route( $namespace, '/my-account/opinions', array(
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'motorlan_get_my_opinions_callback',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        }
+    ) );
+
+    // Route for getting current user's favorites
+    register_rest_route( $namespace, '/my-account/favorites', array(
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'motorlan_get_my_favorites_callback',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        }
+    ) );
+}
+add_action( 'rest_api_init', 'motorlan_register_my_account_rest_routes' );
+
+/**
+ * Callback function to get a list of current user's purchases.
+ */
+function motorlan_get_my_purchases_callback( $request ) {
+    $user_id = get_current_user_id();
+
+    $args = array(
+        'post_type'      => 'compra',
+        'posts_per_page' => -1,
+        'meta_query' => array(
+            array(
+                'key'     => 'usuario',
+                'value'   => $user_id,
+                'compare' => '=',
+            ),
+        ),
+    );
+
+    $query = new WP_Query( $args );
+    $data = array();
+
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $post_id = get_the_ID();
+
+            $motor_post = get_field('motor', $post_id);
+            $motor_data = null;
+            if ($motor_post) {
+                $motor_data = motorlan_get_motor_data($motor_post->ID);
+            }
+
+            $data[] = array(
+                'id'           => $post_id,
+                'title'        => get_the_title(),
+                'fecha_compra' => get_field('fecha_compra', $post_id),
+                'motor'        => $motor_data,
+            );
+        }
+        wp_reset_postdata();
+    }
+
+    return new WP_REST_Response( $data, 200 );
+}
+
+/**
+ * Callback function to get a list of current user's questions.
+ */
+function motorlan_get_my_questions_callback( $request ) {
+    $user_id = get_current_user_id();
+
+    $args = array(
+        'post_type'      => 'pregunta',
+        'posts_per_page' => -1,
+        'meta_query' => array(
+            array(
+                'key'     => 'usuario',
+                'value'   => $user_id,
+                'compare' => '=',
+            ),
+        ),
+    );
+
+    $query = new WP_Query( $args );
+    $data = array();
+
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $post_id = get_the_ID();
+
+            $motor_post = get_field('motor', $post_id);
+            $motor_data = null;
+            if ($motor_post) {
+                $motor_data = motorlan_get_motor_data($motor_post->ID);
+            }
+
+            $data[] = array(
+                'id'        => $post_id,
+                'title'     => get_the_title(),
+                'pregunta'  => get_field('pregunta', $post_id),
+                'respuesta' => get_field('respuesta', $post_id),
+                'motor'     => $motor_data,
+            );
+        }
+        wp_reset_postdata();
+    }
+
+    return new WP_REST_Response( $data, 200 );
+}
+
+/**
+ * Callback function to get a list of current user's opinions.
+ */
+function motorlan_get_my_opinions_callback( $request ) {
+    $user_id = get_current_user_id();
+
+    $args = array(
+        'post_type'      => 'opinion',
+        'posts_per_page' => -1,
+        'meta_query' => array(
+            array(
+                'key'     => 'usuario',
+                'value'   => $user_id,
+                'compare' => '=',
+            ),
+        ),
+    );
+
+    $query = new WP_Query( $args );
+    $data = array();
+
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $post_id = get_the_ID();
+
+            $motor_post = get_field('motor', $post_id);
+            $motor_data = null;
+            if ($motor_post) {
+                $motor_data = motorlan_get_motor_data($motor_post->ID);
+            }
+
+            $data[] = array(
+                'id'         => $post_id,
+                'title'      => get_the_title(),
+                'valoracion' => get_field('valoracion', $post_id),
+                'comentario' => get_field('comentario', $post_id),
+                'motor'      => $motor_data,
+            );
+        }
+        wp_reset_postdata();
+    }
+
+    return new WP_REST_Response( $data, 200 );
+}
+
+/**
+ * Callback function to get a list of current user's favorites.
+ */
+function motorlan_get_my_favorites_callback( $request ) {
+    $user_id = get_current_user_id();
+    $favorite_ids = get_user_meta( $user_id, 'favorite_motors', true );
+
+    if ( empty( $favorite_ids ) ) {
+        return new WP_REST_Response( array(), 200 );
+    }
+
+    $args = array(
+        'post_type'      => 'motor',
+        'posts_per_page' => -1,
+        'post__in'       => $favorite_ids,
+    );
+
+    $query = new WP_Query( $args );
+    $data = array();
+
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $post_id = get_the_ID();
+            $data[] = motorlan_get_motor_data( $post_id );
+        }
+        wp_reset_postdata();
+    }
+
+    return new WP_REST_Response( $data, 200 );
+}

--- a/wp-content/plugins/motorlan-api-vue/includes/cpt-setup-purchases.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/cpt-setup-purchases.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Setup for Custom Post Types "Compra", "Pregunta", "Opinion".
+ *
+ * @package motorlan-api-vue
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Register a custom post type called "compra".
+ */
+function motorlan_register_compra_cpt() {
+    $labels = array(
+        'name'               => _x( 'Compras', 'post type general name', 'motorlan-api-vue' ),
+        'singular_name'      => _x( 'Compra', 'post type singular name', 'motorlan-api-vue' ),
+        'menu_name'          => _x( 'Compras', 'admin menu', 'motorlan-api-vue' ),
+        'name_admin_bar'     => _x( 'Compra', 'add new on admin bar', 'motorlan-api-vue' ),
+        'add_new'            => _x( 'Añadir Nueva', 'compra', 'motorlan-api-vue' ),
+        'add_new_item'       => __( 'Añadir Nueva Compra', 'motorlan-api-vue' ),
+        'new_item'           => __( 'Nueva Compra', 'motorlan-api-vue' ),
+        'edit_item'          => __( 'Editar Compra', 'motorlan-api-vue' ),
+        'view_item'          => __( 'Ver Compra', 'motorlan-api-vue' ),
+        'all_items'          => __( 'Todas las Compras', 'motorlan-api-vue' ),
+        'search_items'       => __( 'Buscar Compras', 'motorlan-api-vue' ),
+        'not_found'          => __( 'No se encontraron compras.', 'motorlan-api-vue' ),
+        'not_found_in_trash' => __( 'No se encontraron compras en la papelera.', 'motorlan-api-vue' )
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'publicly_queryable' => true,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'query_var'          => true,
+        'rewrite'            => array( 'slug' => 'compra' ),
+        'capability_type'    => 'post',
+        'has_archive'        => true,
+        'hierarchical'       => false,
+        'menu_position'      => 6,
+        'supports'           => array( 'title', 'editor', 'custom-fields' ),
+        'show_in_rest'       => true,
+    );
+
+    register_post_type( 'compra', $args );
+}
+add_action( 'init', 'motorlan_register_compra_cpt' );
+
+/**
+ * Register a custom post type called "pregunta".
+ */
+function motorlan_register_pregunta_cpt() {
+    $labels = array(
+        'name'               => _x( 'Preguntas', 'post type general name', 'motorlan-api-vue' ),
+        'singular_name'      => _x( 'Pregunta', 'post type singular name', 'motorlan-api-vue' ),
+        'menu_name'          => _x( 'Preguntas', 'admin menu', 'motorlan-api-vue' ),
+        'name_admin_bar'     => _x( 'Pregunta', 'add new on admin bar', 'motorlan-api-vue' ),
+        'add_new'            => _x( 'Añadir Nueva', 'pregunta', 'motorlan-api-vue' ),
+        'add_new_item'       => __( 'Añadir Nueva Pregunta', 'motorlan-api-vue' ),
+        'new_item'           => __( 'Nueva Pregunta', 'motorlan-api-vue' ),
+        'edit_item'          => __( 'Editar Pregunta', 'motorlan-api-vue' ),
+        'view_item'          => __( 'Ver Pregunta', 'motorlan-api-vue' ),
+        'all_items'          => __( 'Todas las Preguntas', 'motorlan-api-vue' ),
+        'search_items'       => __( 'Buscar Preguntas', 'motorlan-api-vue' ),
+        'not_found'          => __( 'No se encontraron preguntas.', 'motorlan-api-vue' ),
+        'not_found_in_trash' => __( 'No se encontraron preguntas en la papelera.', 'motorlan-api-vue' )
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'publicly_queryable' => true,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'query_var'          => true,
+        'rewrite'            => array( 'slug' => 'pregunta' ),
+        'capability_type'    => 'post',
+        'has_archive'        => true,
+        'hierarchical'       => false,
+        'menu_position'      => 7,
+        'supports'           => array( 'title', 'editor', 'custom-fields' ),
+        'show_in_rest'       => true,
+    );
+
+    register_post_type( 'pregunta', $args );
+}
+add_action( 'init', 'motorlan_register_pregunta_cpt' );
+
+/**
+ * Register a custom post type called "opinion".
+ */
+function motorlan_register_opinion_cpt() {
+    $labels = array(
+        'name'               => _x( 'Opiniones', 'post type general name', 'motorlan-api-vue' ),
+        'singular_name'      => _x( 'Opinión', 'post type singular name', 'motorlan-api-vue' ),
+        'menu_name'          => _x( 'Opiniones', 'admin menu', 'motorlan-api-vue' ),
+        'name_admin_bar'     => _x( 'Opinión', 'add new on admin bar', 'motorlan-api-vue' ),
+        'add_new'            => _x( 'Añadir Nueva', 'opinion', 'motorlan-api-vue' ),
+        'add_new_item'       => __( 'Añadir Nueva Opinión', 'motorlan-api-vue' ),
+        'new_item'           => __( 'Nueva Opinión', 'motorlan-api-vue' ),
+        'edit_item'          => __( 'Editar Opinión', 'motorlan-api-vue' ),
+        'view_item'          => __( 'Ver Opinión', 'motorlan-api-vue' ),
+        'all_items'          => __( 'Todas las Opiniones', 'motorlan-api-vue' ),
+        'search_items'       => __( 'Buscar Opiniones', 'motorlan-api-vue' ),
+        'not_found'          => __( 'No se encontraron opiniones.', 'motorlan-api-vue' ),
+        'not_found_in_trash' => __( 'No se encontraron opiniones en la papelera.', 'motorlan-api-vue' )
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'publicly_queryable' => true,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'query_var'          => true,
+        'rewrite'            => array( 'slug' => 'opinion' ),
+        'capability_type'    => 'post',
+        'has_archive'        => true,
+        'hierarchical'       => false,
+        'menu_position'      => 8,
+        'supports'           => array( 'title', 'editor', 'custom-fields' ),
+        'show_in_rest'       => true,
+    );
+
+    register_post_type( 'opinion', $args );
+}
+add_action( 'init', 'motorlan_register_opinion_cpt' );

--- a/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
+++ b/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
@@ -21,8 +21,11 @@ define( 'MOTORLAN_API_VUE_PATH', plugin_dir_path( __FILE__ ) );
 
 // Include required files
 require_once MOTORLAN_API_VUE_PATH . 'includes/cpt-setup.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/cpt-setup-purchases.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/acf-setup.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/acf-setup-purchases.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/motor-routes.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/api/my-account-routes.php';
 
 require_once MOTORLAN_API_VUE_PATH . 'includes/admin-mods.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/vue-app-setup.php';


### PR DESCRIPTION
…nd favorites

This commit introduces a new 'My Account' section in the Vue application, allowing users to view their activity.

- Adds new Custom Post Types (CPTs) for 'Compra' (Purchase), 'Pregunta' (Question), and 'Opinion'.
- Defines Advanced Custom Fields (ACFs) for the new CPTs.
- Creates new REST API endpoints to fetch the current user's purchases, questions, opinions, and favorite motors.
- Implements the frontend components for the 'My Account' section, including a tabbed layout and data tables to display the information.
- Adds a link to the 'My Account' section in the main navigation.