### PR TITLE
fix: Correct routing and update titles for My Account section

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
@@ -39,13 +39,13 @@ export default [
     ],
   },
   {
-    title: 'My Account',
+    title: 'Mis Compras',
     icon: { icon: 'tabler-user-circle' },
     children: [
-      { title: 'Purchases', to: '/apps/my-account/purchases' },
-      { title: 'Questions', to: '/apps/my-account/questions' },
-      { title: 'Opinions', to: '/apps/my-account/opinions' },
-      { title: 'Favorites', to: '/apps/my-account/favorites' },
+      { title: 'Compras', to: 'apps-my-account-purchases' },
+      { title: 'Preguntas', to: 'apps-my-account-questions' },
+      { title: 'Opiniones', to: 'apps-my-account-opinions' },
+      { title: 'Favoritos', to: 'apps-my-account-favorites' },
     ],
   },
 ]

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account.vue
@@ -2,37 +2,43 @@
 const route = useRoute()
 
 const tabs = [
-  { title: 'Compras', to: '/apps/my-account/purchases' },
-  { title: 'Preguntas', to: '/apps/my-account/questions' },
-  { title: 'Opiniones', to: '/apps/my-account/opinions' },
-  { title: 'Favoritos', to: '/apps/my-account/favorites' },
+  { title: 'Compras', to: { name: 'apps-my-account-purchases' } },
+  { title: 'Preguntas', to: { name: 'apps-my-account-questions' } },
+  { title: 'Opiniones', to: { name: 'apps-my-account-opinions' } },
+  { title: 'Favoritos', to: { name: 'apps-my-account-favorites' } },
 ]
+
+const activeTab = computed({
+  get: () => tabs.findIndex(tab => tab.to.name === route.name),
+  set: val => {
+    navigateTo(tabs[val].to)
+  },
+})
 </script>
 
 <template>
   <div>
     <VTabs
-      :model-value="route.path"
+      v-model="activeTab"
       class="v-tabs-pill"
     >
       <VTab
         v-for="tab in tabs"
-        :key="tab.to"
+        :key="tab.to.name"
         :to="tab.to"
-        :value="tab.to"
       >
         {{ tab.title }}
       </VTab>
     </VTabs>
 
     <VWindow
-      :model-value="route.path"
+      v-model="activeTab"
       class="mt-6"
+      :touch="false"
     >
       <VWindowItem
         v-for="tab in tabs"
-        :key="tab.to"
-        :value="tab.to"
+        :key="tab.to.name"
       >
         <NuxtPage />
       </VWindowItem>


### PR DESCRIPTION
This commit fixes a routing issue in the 'My Account' section by switching from path-based navigation to named routes. This resolves the 'No match for...' error from vue-router.

Additionally, it updates the titles in the navigation and tabs to Spanish as requested by the user.