### PR TITLE
fix: Remove non-existent useUser composable

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/favorites.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/favorites.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import { useUser } from '~/composables/useUser'
-
-const { user } = useUser()
-
 const { data: favorites, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/favorites'))
 
 const headers = [

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/opinions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/opinions.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import { useUser } from '~/composables/useUser'
-
-const { user } = useUser()
-
 const { data: opinions, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/opinions'))
 
 const headers = [

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/purchases.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/purchases.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import { useUser } from '~/composables/useUser'
-
-const { user } = useUser()
-
 const { data: purchases, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/purchases'))
 
 const headers = [

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/questions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/questions.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import { useUser } from '~/composables/useUser'
-
-const { user } = useUser()
-
 const { data: questions, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/questions'))
 
 const headers = [


### PR DESCRIPTION
This commit removes the import and usage of the `useUser` composable from the 'My Account' pages. This composable does not exist in the project and was causing a Vite build error.

The API calls for the 'My Account' section rely on cookie-based authentication, so the user data is not needed on the client-side for these requests to succeed.