### PR TITLE
feat: Redesign 'My Account' pages and add pagination

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/favorites.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/favorites.vue
@@ -1,35 +1,134 @@
 <script setup lang="ts">
-const { data: favorites, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/favorites'))
+import type { ImagenDestacada } from '../../../../../interfaces/motor'
 
 const headers = [
-  { title: 'Motor', key: 'motor.title' },
+  { title: 'Motor', key: 'motor' },
+  { title: 'Referencia', key: 'referencia' },
+  { title: 'Precio', key: 'precio' },
 ]
+
+const searchQuery = ref('')
+const selectedRows = ref([])
+
+// Data table options
+const itemsPerPage = ref(10)
+const page = ref(1)
+const sortBy = ref()
+const orderBy = ref()
+
+// Update data table options
+const updateOptions = (options: any) => {
+  page.value = options.page
+  sortBy.value = options.sortBy[0]?.key
+  orderBy.value = options.sortBy[0]?.order
+}
+
+const { data: favoritesData, execute: fetchFavorites } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/favorites', {
+  query: {
+    page,
+    per_page: itemsPerPage,
+    orderby: sortBy,
+    order: orderBy,
+    search: searchQuery,
+  },
+}))
+
+const favorites = computed(() => favoritesData.value?.data || [])
+const totalFavorites = computed(() => favoritesData.value?.pagination.total || 0)
+
+const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail'): string => {
+  let imageObj: ImagenDestacada | null = null
+
+  if (Array.isArray(image) && image.length > 0)
+    imageObj = image[0]
+  else if (image && !Array.isArray(image))
+    imageObj = image as ImagenDestacada
+
+  if (!imageObj)
+    return ''
+
+  if (imageObj.sizes && imageObj.sizes[size])
+    return imageObj.sizes[size] as string
+
+  return imageObj.url || ''
+}
 </script>
 
 <template>
-  <VCard>
-    <VCardTitle>Mis Favoritos</VCardTitle>
+  <VCard
+    id="favorite-list"
+  >
     <VCardText>
-      <VDataTable
-        :headers="headers"
-        :items="favorites"
-        :loading="pending"
-        class="elevation-1"
-      >
-        <template #item.motor.title="{ item }">
-          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
-            {{ item.raw.motor.title }}
-          </NuxtLink>
-        </template>
-        <template #loading>
-          <VSkeletonLoader type="table-row@10" />
-        </template>
-        <template #no-data>
-          <p class="text-center">
-            No tienes motores favoritos.
-          </p>
-        </template>
-      </VDataTable>
+      <div class="d-flex flex-wrap gap-4">
+        <div class="d-flex align-center">
+          <!-- 👉 Search  -->
+          <AppTextField
+            v-model="searchQuery"
+            placeholder="Buscar Favorito"
+            style="inline-size: 200px;"
+            class="me-3"
+          />
+        </div>
+
+        <VSpacer />
+        <div class="d-flex gap-4 flex-wrap align-center">
+          <AppSelect
+            v-model="itemsPerPage"
+            :items="[5, 10, 20, 25, 50]"
+          />
+        </div>
+      </div>
     </VCardText>
+
+    <VDivider />
+
+    <!-- 👉 Datatable  -->
+    <VDataTableServer
+      v-model:items-per-page="itemsPerPage"
+      v-model:page="page"
+      :headers="headers"
+      :items="favorites"
+      :items-length="totalFavorites"
+      class="text-no-wrap"
+      @update:options="updateOptions"
+    >
+      <!-- motor -->
+      <template #item.motor="{ item }">
+        <div class="d-flex align-center gap-x-4">
+          <VAvatar
+            v-if="item.raw.imagen_destacada"
+            size="38"
+            variant="tonal"
+            rounded
+            :image="getImageBySize(item.raw.imagen_destacada, 'thumbnail')"
+          />
+          <div class="d-flex flex-column">
+            <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.uuid}`">
+              <span class="text-body-1 font-weight-medium text-high-emphasis">{{ item.raw.title }}</span>
+            </NuxtLink>
+            <span class="text-body-2">{{ item.raw.acf.marca.name }}</span>
+          </div>
+        </div>
+      </template>
+
+      <!-- referencia -->
+      <template #item.referencia="{ item }">
+        <span class="text-body-1 text-high-emphasis">{{ item.raw.acf.tipo_o_referencia }}</span>
+      </template>
+
+      <!-- precio -->
+      <template #item.precio="{ item }">
+        <span class="text-body-1 text-high-emphasis">{{ item.raw.acf.precio_de_venta }}</span>
+      </template>
+
+      <!-- pagination -->
+      <template #bottom>
+        <TablePagination
+          v-model:page="page"
+          :items-per-page="itemsPerPage"
+          :total-items="totalFavorites"
+        />
+      </template>
+    </VDataTableServer>
   </VCard>
 </template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/opinions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/opinions.vue
@@ -1,45 +1,139 @@
 <script setup lang="ts">
-const { data: opinions, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/opinions'))
+import type { ImagenDestacada } from '../../../../../interfaces/motor'
 
 const headers = [
-  { title: 'Motor', key: 'motor.title' },
+  { title: 'Motor', key: 'motor' },
   { title: 'Valoración', key: 'valoracion' },
   { title: 'Comentario', key: 'comentario' },
 ]
+
+const searchQuery = ref('')
+const selectedRows = ref([])
+
+// Data table options
+const itemsPerPage = ref(10)
+const page = ref(1)
+const sortBy = ref()
+const orderBy = ref()
+
+// Update data table options
+const updateOptions = (options: any) => {
+  page.value = options.page
+  sortBy.value = options.sortBy[0]?.key
+  orderBy.value = options.sortBy[0]?.order
+}
+
+const { data: opinionsData, execute: fetchOpinions } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/opinions', {
+  query: {
+    page,
+    per_page: itemsPerPage,
+    orderby: sortBy,
+    order: orderBy,
+    search: searchQuery,
+  },
+}))
+
+const opinions = computed(() => opinionsData.value?.data || [])
+const totalOpinions = computed(() => opinionsData.value?.pagination.total || 0)
+
+const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail'): string => {
+  let imageObj: ImagenDestacada | null = null
+
+  if (Array.isArray(image) && image.length > 0)
+    imageObj = image[0]
+  else if (image && !Array.isArray(image))
+    imageObj = image as ImagenDestacada
+
+  if (!imageObj)
+    return ''
+
+  if (imageObj.sizes && imageObj.sizes[size])
+    return imageObj.sizes[size] as string
+
+  return imageObj.url || ''
+}
 </script>
 
 <template>
-  <VCard>
-    <VCardTitle>Mis Opiniones</VCardTitle>
+  <VCard
+    id="opinion-list"
+  >
     <VCardText>
-      <VDataTable
-        :headers="headers"
-        :items="opinions"
-        :loading="pending"
-        class="elevation-1"
-      >
-        <template #item.motor.title="{ item }">
-          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
-            {{ item.raw.motor.title }}
-          </NuxtLink>
-        </template>
-        <template #item.valoracion="{ item }">
-          <VRating
-            :model-value="item.raw.valoracion"
-            readonly
-            dense
-            size="small"
+      <div class="d-flex flex-wrap gap-4">
+        <div class="d-flex align-center">
+          <!-- 👉 Search  -->
+          <AppTextField
+            v-model="searchQuery"
+            placeholder="Buscar Opinión"
+            style="inline-size: 200px;"
+            class="me-3"
           />
-        </template>
-        <template #loading>
-          <VSkeletonLoader type="table-row@10" />
-        </template>
-        <template #no-data>
-          <p class="text-center">
-            No has realizado ninguna opinión.
-          </p>
-        </template>
-      </VDataTable>
+        </div>
+
+        <VSpacer />
+        <div class="d-flex gap-4 flex-wrap align-center">
+          <AppSelect
+            v-model="itemsPerPage"
+            :items="[5, 10, 20, 25, 50]"
+          />
+        </div>
+      </div>
     </VCardText>
+
+    <VDivider />
+
+    <!-- 👉 Datatable  -->
+    <VDataTableServer
+      v-model:items-per-page="itemsPerPage"
+      v-model:page="page"
+      :headers="headers"
+      :items="opinions"
+      :items-length="totalOpinions"
+      class="text-no-wrap"
+      @update:options="updateOptions"
+    >
+      <!-- motor -->
+      <template #item.motor="{ item }">
+        <div class="d-flex align-center gap-x-4">
+          <VAvatar
+            v-if="item.raw.motor?.imagen_destacada"
+            size="38"
+            variant="tonal"
+            rounded
+            :image="getImageBySize(item.raw.motor.imagen_destacada, 'thumbnail')"
+          />
+          <div class="d-flex flex-column">
+            <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
+              <span class="text-body-1 font-weight-medium text-high-emphasis">{{ item.raw.motor.title }}</span>
+            </NuxtLink>
+            <span class="text-body-2">{{ item.raw.motor.acf.marca.name }}</span>
+          </div>
+        </div>
+      </template>
+
+      <!-- valoracion -->
+      <template #item.valoracion="{ item }">
+        <VRating
+          :model-value="item.raw.valoracion"
+          readonly
+          dense
+          size="small"
+        />
+      </template>
+
+      <!-- comentario -->
+      <template #item.comentario="{ item }">
+        <span class="text-body-1 text-high-emphasis">{{ item.raw.comentario }}</span>
+      </template>
+
+      <!-- pagination -->
+      <template #bottom>
+        <TablePagination
+          v-model:page="page"
+          :items-per-page="itemsPerPage"
+          :total-items="totalOpinions"
+        />
+      </template>
+    </VDataTableServer>
   </VCard>
 </template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/questions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/my-account/questions.vue
@@ -1,37 +1,134 @@
 <script setup lang="ts">
-const { data: questions, pending, error } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/questions'))
+import type { ImagenDestacada } from '../../../../../interfaces/motor'
 
 const headers = [
-  { title: 'Motor', key: 'motor.title' },
+  { title: 'Motor', key: 'motor' },
   { title: 'Pregunta', key: 'pregunta' },
   { title: 'Respuesta', key: 'respuesta' },
 ]
+
+const searchQuery = ref('')
+const selectedRows = ref([])
+
+// Data table options
+const itemsPerPage = ref(10)
+const page = ref(1)
+const sortBy = ref()
+const orderBy = ref()
+
+// Update data table options
+const updateOptions = (options: any) => {
+  page.value = options.page
+  sortBy.value = options.sortBy[0]?.key
+  orderBy.value = options.sortBy[0]?.order
+}
+
+const { data: questionsData, execute: fetchQuestions } = await useApi<any>(createUrl('/wp-json/motorlan/v1/my-account/questions', {
+  query: {
+    page,
+    per_page: itemsPerPage,
+    orderby: sortBy,
+    order: orderBy,
+    search: searchQuery,
+  },
+}))
+
+const questions = computed(() => questionsData.value?.data || [])
+const totalQuestions = computed(() => questionsData.value?.pagination.total || 0)
+
+const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail'): string => {
+  let imageObj: ImagenDestacada | null = null
+
+  if (Array.isArray(image) && image.length > 0)
+    imageObj = image[0]
+  else if (image && !Array.isArray(image))
+    imageObj = image as ImagenDestacada
+
+  if (!imageObj)
+    return ''
+
+  if (imageObj.sizes && imageObj.sizes[size])
+    return imageObj.sizes[size] as string
+
+  return imageObj.url || ''
+}
 </script>
 
 <template>
-  <VCard>
-    <VCardTitle>Mis Preguntas</VCardTitle>
+  <VCard
+    id="question-list"
+  >
     <VCardText>
-      <VDataTable
-        :headers="headers"
-        :items="questions"
-        :loading="pending"
-        class="elevation-1"
-      >
-        <template #item.motor.title="{ item }">
-          <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
-            {{ item.raw.motor.title }}
-          </NuxtLink>
-        </template>
-        <template #loading>
-          <VSkeletonLoader type="table-row@10" />
-        </template>
-        <template #no-data>
-          <p class="text-center">
-            No has realizado ninguna pregunta.
-          </p>
-        </template>
-      </VDataTable>
+      <div class="d-flex flex-wrap gap-4">
+        <div class="d-flex align-center">
+          <!-- 👉 Search  -->
+          <AppTextField
+            v-model="searchQuery"
+            placeholder="Buscar Pregunta"
+            style="inline-size: 200px;"
+            class="me-3"
+          />
+        </div>
+
+        <VSpacer />
+        <div class="d-flex gap-4 flex-wrap align-center">
+          <AppSelect
+            v-model="itemsPerPage"
+            :items="[5, 10, 20, 25, 50]"
+          />
+        </div>
+      </div>
     </VCardText>
+
+    <VDivider />
+
+    <!-- 👉 Datatable  -->
+    <VDataTableServer
+      v-model:items-per-page="itemsPerPage"
+      v-model:page="page"
+      :headers="headers"
+      :items="questions"
+      :items-length="totalQuestions"
+      class="text-no-wrap"
+      @update:options="updateOptions"
+    >
+      <!-- motor -->
+      <template #item.motor="{ item }">
+        <div class="d-flex align-center gap-x-4">
+          <VAvatar
+            v-if="item.raw.motor?.imagen_destacada"
+            size="38"
+            variant="tonal"
+            rounded
+            :image="getImageBySize(item.raw.motor.imagen_destacada, 'thumbnail')"
+          />
+          <div class="d-flex flex-column">
+            <NuxtLink :to="`/apps/motors/motor/edit/${item.raw.motor.uuid}`">
+              <span class="text-body-1 font-weight-medium text-high-emphasis">{{ item.raw.motor.title }}</span>
+            </NuxtLink>
+            <span class="text-body-2">{{ item.raw.motor.acf.marca.name }}</span>
+          </div>
+        </div>
+      </template>
+
+      <!-- pregunta -->
+      <template #item.pregunta="{ item }">
+        <span class="text-body-1 text-high-emphasis">{{ item.raw.pregunta }}</span>
+      </template>
+
+      <!-- respuesta -->
+      <template #item.respuesta="{ item }">
+        <span class="text-body-1 text-high-emphasis">{{ item.raw.respuesta || 'Sin respuesta' }}</span>
+      </template>
+
+      <!-- pagination -->
+      <template #bottom>
+        <TablePagination
+          v-model:page="page"
+          :items-per-page="itemsPerPage"
+          :total-items="totalQuestions"
+        />
+      </template>
+    </VDataTableServer>
   </VCard>
 </template>

--- a/wp-content/plugins/motorlan-api-vue/includes/api/my-account-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/my-account-routes.php
@@ -59,10 +59,15 @@ add_action( 'rest_api_init', 'motorlan_register_my_account_rest_routes' );
  */
 function motorlan_get_my_purchases_callback( $request ) {
     $user_id = get_current_user_id();
+    $page = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
+    $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : 10;
+    $search = $request->get_param( 'search' );
 
     $args = array(
         'post_type'      => 'compra',
-        'posts_per_page' => -1,
+        's'              => $search,
+        'posts_per_page' => $per_page,
+        'paged'          => $page,
         'meta_query' => array(
             array(
                 'key'     => 'usuario',
@@ -96,7 +101,19 @@ function motorlan_get_my_purchases_callback( $request ) {
         wp_reset_postdata();
     }
 
-    return new WP_REST_Response( $data, 200 );
+    $pagination = array(
+        'total'     => (int) $query->found_posts,
+        'totalPages' => (int) $query->max_num_pages,
+        'currentPage'    => (int) $page,
+        'perPage'   => (int) $per_page,
+    );
+
+    $response_data = array(
+        'data'      => $data,
+        'pagination' => $pagination,
+    );
+
+    return new WP_REST_Response( $response_data, 200 );
 }
 
 /**
@@ -104,10 +121,15 @@ function motorlan_get_my_purchases_callback( $request ) {
  */
 function motorlan_get_my_questions_callback( $request ) {
     $user_id = get_current_user_id();
+    $page = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
+    $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : 10;
+    $search = $request->get_param( 'search' );
 
     $args = array(
         'post_type'      => 'pregunta',
-        'posts_per_page' => -1,
+        's'              => $search,
+        'posts_per_page' => $per_page,
+        'paged'          => $page,
         'meta_query' => array(
             array(
                 'key'     => 'usuario',
@@ -142,7 +164,19 @@ function motorlan_get_my_questions_callback( $request ) {
         wp_reset_postdata();
     }
 
-    return new WP_REST_Response( $data, 200 );
+    $pagination = array(
+        'total'     => (int) $query->found_posts,
+        'totalPages' => (int) $query->max_num_pages,
+        'currentPage'    => (int) $page,
+        'perPage'   => (int) $per_page,
+    );
+
+    $response_data = array(
+        'data'      => $data,
+        'pagination' => $pagination,
+    );
+
+    return new WP_REST_Response( $response_data, 200 );
 }
 
 /**
@@ -150,10 +184,15 @@ function motorlan_get_my_questions_callback( $request ) {
  */
 function motorlan_get_my_opinions_callback( $request ) {
     $user_id = get_current_user_id();
+    $page = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
+    $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : 10;
+    $search = $request->get_param( 'search' );
 
     $args = array(
         'post_type'      => 'opinion',
-        'posts_per_page' => -1,
+        's'              => $search,
+        'posts_per_page' => $per_page,
+        'paged'          => $page,
         'meta_query' => array(
             array(
                 'key'     => 'usuario',
@@ -188,7 +227,19 @@ function motorlan_get_my_opinions_callback( $request ) {
         wp_reset_postdata();
     }
 
-    return new WP_REST_Response( $data, 200 );
+    $pagination = array(
+        'total'     => (int) $query->found_posts,
+        'totalPages' => (int) $query->max_num_pages,
+        'currentPage'    => (int) $page,
+        'perPage'   => (int) $per_page,
+    );
+
+    $response_data = array(
+        'data'      => $data,
+        'pagination' => $pagination,
+    );
+
+    return new WP_REST_Response( $response_data, 200 );
 }
 
 /**
@@ -196,15 +247,19 @@ function motorlan_get_my_opinions_callback( $request ) {
  */
 function motorlan_get_my_favorites_callback( $request ) {
     $user_id = get_current_user_id();
+    $page = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
+    $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : 10;
+
     $favorite_ids = get_user_meta( $user_id, 'favorite_motors', true );
 
     if ( empty( $favorite_ids ) ) {
-        return new WP_REST_Response( array(), 200 );
+        return new WP_REST_Response( array( 'data' => [], 'pagination' => [ 'total' => 0 ] ), 200 );
     }
 
     $args = array(
         'post_type'      => 'motor',
-        'posts_per_page' => -1,
+        'posts_per_page' => $per_page,
+        'paged'          => $page,
         'post__in'       => $favorite_ids,
     );
 
@@ -220,5 +275,20 @@ function motorlan_get_my_favorites_callback( $request ) {
         wp_reset_postdata();
     }
 
-    return new WP_REST_Response( $data, 200 );
+    $total_favorites = count($favorite_ids);
+    $max_num_pages = ceil($total_favorites / $per_page);
+
+    $pagination = array(
+        'total'     => (int) $total_favorites,
+        'totalPages' => (int) $max_num_pages,
+        'currentPage'    => (int) $page,
+        'perPage'   => (int) $per_page,
+    );
+
+    $response_data = array(
+        'data'      => $data,
+        'pagination' => $pagination,
+    );
+
+    return new WP_REST_Response( $response_data, 200 );
 }


### PR DESCRIPTION
This commit refactors the 'My Account' pages (Purchases, Questions, Opinions, Favorites) to match the design and layout of the main motor list page.

- Backend: Adds pagination and search support to the 'My Account' API endpoints.
- Frontend: Updates the Vue components to use `VDataTableServer` for server-side pagination, adds a search bar, and styles the table content to be consistent with the rest of the application.