### PR TITLE
Disable motor card links without uuid

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/motores/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/motores/index.vue
@@ -321,9 +321,25 @@ const handleFilterSearch = () => {
             md="4"
           >
             <VCard
+              v-if="motor.uuid"
               class="product-card"
-              v-bind="motor.uuid ? { to: `/motores/${motor.uuid}` } : {}"
+              :to="`/motores/${motor.uuid}`"
             >
+              <div class="product-card-inner">
+                <div class="product-image-background">
+                  <VImg :src="motor.imagen_destacada?.url" height="185" />
+                </div>
+                <div class="product-name">{{ motor.title }}</div>
+                <div class="product-price">{{ motor.acf.precio_de_venta ? `${motor.acf.precio_de_venta} €` : 'Consultar' }}</div>
+                <div class="info-button">
+                  <div class="info-button-text">+ INFO</div>
+                  <div class="info-button-icon-container">
+                    <div class="info-button-icon"></div>
+                  </div>
+                </div>
+              </div>
+            </VCard>
+            <VCard v-else class="product-card">
               <div class="product-card-inner">
                 <div class="product-image-background">
                   <VImg :src="motor.imagen_destacada?.url" height="185" />


### PR DESCRIPTION
## Summary
- only enable motor detail links when a motor has a uuid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ENOENT: no such file or directory, scandir 'eslint-internal-rules')*
- `npm run typecheck` *(no output, interrupted after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f5ebefc832fa6527d3bcd5335f4