### PR TITLE
feat: redesign motors listing page

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
@@ -4,7 +4,6 @@ import { useApi } from '@/composables/useApi';
 import { createUrl } from '@/@core/composable/createUrl';
 import type { Motor } from '@/interfaces/motor';
 
-// Define interfaces for our data structures
 interface Term {
   id: number;
   name: string;
@@ -12,33 +11,38 @@ interface Term {
 }
 
 // -- State Management --
-
-// Filter state
 const selectedCategory = ref<string | null>(null);
 const selectedBrand = ref<number | null>(null);
 const selectedCountry = ref<string | null>(null);
 const selectedState = ref<string | null>(null);
+const typeModel = ref('');
+const productTypes = ref<string[]>([]);
+const selectedPar = ref<string | null>(null);
+const selectedPotencia = ref<string | null>(null);
+const selectedVelocidad = ref<string | null>(null);
+const searchTerm = ref('');
+const order = ref<string | null>(null);
 
-// Pagination state
+const parOptions = ['0-50', '50-100'];
+const potenciaOptions = ['0-1 kW', '1-5 kW'];
+const velocidadOptions = ['500 rpm', '1500 rpm'];
+const orderOptions = ['Recientes', 'Precio asc', 'Precio desc'];
+
 const itemsPerPage = ref(9);
 const page = ref(1);
 
 // -- Data Fetching --
-
-// Fetch categories for the filter dropdown
 const { data: categoriesData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/motor-categories'));
 const categories = computed(() => categoriesData.value || []);
 
-// Fetch brands for the filter dropdown
 const { data: brandsData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/marcas'));
 const marcas = computed(() => brandsData.value || []);
 
-// Reactive URL for fetching motors
 const motorsApiUrl = createUrl('/wp-json/motorlan/v1/motors', {
   query: {
     per_page: itemsPerPage,
     page,
-    status: 'publish', // Always fetch published for the shop
+    status: 'publish',
     category: selectedCategory,
     marca: selectedBrand,
     pais: selectedCountry,
@@ -46,135 +50,115 @@ const motorsApiUrl = createUrl('/wp-json/motorlan/v1/motors', {
   },
 });
 
-// Fetch motors
 const { data: motorsData, isFetching: loading } = await useApi<any>(motorsApiUrl).get().json();
 
-// Computed properties to extract data from the API response
 const motors = computed((): Motor[] => motorsData.value?.data || []);
 const totalMotors = computed(() => motorsData.value?.pagination.total || 0);
 const totalPages = computed(() => motorsData.value?.pagination.totalPages || 1);
-
 </script>
 
 <template>
-  <VRow>
-    <!-- Filters Sidebar -->
-    <VCol cols="12" md="3">
-      <VCard>
-        <VCardItem>
-          <VCardTitle class="text-error">Filtros</VCardTitle>
-        </VCardItem>
-        <VCardText>
-            <!-- Category Filter -->
-            <AppSelect
-              v-model="selectedCategory"
-              label="Categoría"
-              :items="categories"
-              item-title="name"
-              item-value="slug"
-              clearable
-              class="mb-4"
-            />
+  <div class="tienda d-flex">
+    <aside class="filters pa-4">
+      <div class="d-flex align-center mb-2">
+        <VIcon size="18" class="me-2" color="error">mdi-checkbox-blank-outline</VIcon>
+        <span class="text-error font-weight-semibold">FILTROS</span>
+      </div>
+      <VDivider thickness="3" class="mb-4" color="error" />
 
-            <!-- Brand Filter -->
-            <AppSelect
-              v-model="selectedBrand"
-              label="Marca"
-              :items="marcas"
-              item-title="name"
-              item-value="id"
-              clearable
-              class="mb-4"
-            />
+      <VTextField v-model="typeModel" label="Tipo / modelo" variant="outlined" density="comfortable" class="mb-6" />
 
-            <!-- Country Filter -->
-            <AppSelect
-              v-model="selectedCountry"
-              label="País"
-              :items="['España', 'Portugal', 'Francia']"
-              clearable
-              class="mb-4"
-            />
+      <p class="text-body-2 mb-2">Tipo de producto</p>
+      <VCheckbox v-model="productTypes" label="Motor" value="Motor" density="compact" hide-details />
+      <VCheckbox v-model="productTypes" label="Regulador" value="Regulador" density="compact" hide-details />
+      <VCheckbox v-model="productTypes" label="Otros repuestos" value="Otros repuestos" density="compact" hide-details class="mb-6" />
 
-            <!-- State Filter -->
-            <AppSelect
-              v-model="selectedState"
-              label="Estado"
-              :items="['Nuevo', 'Usado', 'Restaurado']"
-              clearable
-              class="mb-4"
-            />
-        </VCardText>
-      </VCard>
-    </VCol>
+      <AppSelect v-model="selectedPar" label="PAR (Nm)" :items="parOptions" class="mb-4" clearable />
+      <AppSelect v-model="selectedPotencia" label="Potencia" :items="potenciaOptions" class="mb-4" clearable />
+      <AppSelect v-model="selectedVelocidad" label="Velocidad" :items="velocidadOptions" class="mb-4" clearable />
+      <AppSelect v-model="selectedBrand" label="Marcas" :items="marcas" item-title="name" item-value="id" class="mb-4" clearable />
+      <AppSelect v-model="selectedState" label="Estado" :items="['Nuevo','Usado','Restaurado']" class="mb-4" clearable />
+    </aside>
 
-    <!-- Products Content -->
-    <VCol cols="12" md="9">
-      <!-- Loading Indicator -->
+    <section class="flex-grow-1 ps-6">
+      <div class="d-flex align-center mb-6">
+        <VTextField v-model="searchTerm" placeholder="Buscar..." variant="outlined" hide-details class="me-4" />
+        <VBtn color="error" class="me-6">Buscar</VBtn>
+        <AppSelect v-model="order" :items="orderOptions" label="Ordenar" clearable style="max-width:220px" />
+      </div>
+
       <div v-if="loading && !motors.length" class="text-center pa-12">
-        <VProgressCircular indeterminate size="64"></VProgressCircular>
+        <VProgressCircular indeterminate size="64" />
         <p class="mt-4">Cargando motores...</p>
       </div>
 
-      <!-- Motors Grid -->
-      <div v-else>
-        <VRow v-if="motors.length > 0">
-          <VCol
-            v-for="motor in motors"
-            :key="motor.id"
-            cols="12"
-            sm="6"
-            md="4"
-          >
-            <VCard>
-              <VImg
-                :src="motor.imagen_destacada?.url || '/placeholder.png'"
-                height="200px"
-                cover
-              ></VImg>
-              <VCardItem>
-                <VCardTitle>{{ motor.title }}</VCardTitle>
-                <VCardSubtitle v-if="motor.acf.marca">
-                  {{ motor.acf.marca.name }}
-                </VCardSubtitle>
-              </VCardItem>
-              <VCardText>
-                <div class="font-weight-bold text-h6 text-error">
-                  {{ motor.acf.precio_de_venta ? `${motor.acf.precio_de_venta} €` : 'Consultar precio' }}
-                </div>
-              </VCardText>
-              <VCardActions>
-                  <!-- The :to prop is temporarily removed to prevent a router crash. -->
-                  <!-- A separate task will be needed to create the single motor page and re-enable this link. -->
-                  <VBtn color="error">
-                  + INFO
-                </VBtn>
-              </VCardActions>
-            </VCard>
-          </VCol>
-        </VRow>
+      <VRow v-else-if="motors.length" class="motor-grid">
+        <VCol
+          v-for="motor in motors"
+          :key="motor.id"
+          cols="12"
+          sm="6"
+          md="4"
+        >
+          <div class="motor-card pa-4">
+            <div class="motor-image mb-6">
+              <img :src="motor.imagen_destacada?.url || '/placeholder.png'" alt="" />
+            </div>
+            <div class="text-error text-body-1 mb-4">
+              {{ motor.title }}
+            </div>
+            <div class="d-flex justify-space-between align-center">
+              <VBtn color="error" class="rounded-pill px-6">+ INFO</VBtn>
+              <div class="price text-error font-weight-bold">
+                {{ motor.acf.precio_de_venta ? `${motor.acf.precio_de_venta} €` : 'Consultar precio' }}
+              </div>
+            </div>
+          </div>
+        </VCol>
+      </VRow>
 
-        <!-- No Results Message -->
-        <VCard v-else class="pa-8 text-center">
-          <VCardText>
-            <p class="text-h6">No se encontraron motores</p>
-            <p>Intenta ajustar los filtros de búsqueda.</p>
-          </VCardText>
-        </VCard>
-      </div>
+      <VCard v-else class="pa-8 text-center">
+        <VCardText>
+          <p class="text-h6">No se encontraron motores</p>
+          <p>Intenta ajustar los filtros de búsqueda.</p>
+        </VCardText>
+      </VCard>
 
-      <!-- Pagination -->
       <VPagination
         v-if="totalPages > 1"
         v-model="page"
         :length="totalPages"
         :total-visible="5"
         class="mt-6"
-      ></VPagination>
-    </VCol>
-  </VRow>
+      />
+    </section>
+  </div>
 </template>
 
 <style scoped>
-/* Add any specific styles here */
+.tienda {
+  align-items: flex-start;
+}
+.filters {
+  width: 300px;
+}
+.motor-card {
+  background: #fff;
+  border-radius: 16px;
+}
+.motor-image {
+  height: 185px;
+  border-radius: 8px;
+  background: #EEF1F4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.motor-image img {
+  max-width: 100%;
+  max-height: 100%;
+}
+.price {
+  font-size: 24px;
+}
 </style>


### PR DESCRIPTION
## Summary
- rebuild motor listing page layout with dedicated filter sidebar and search/order controls
- style motor cards to match design with image, info button and price

## Testing
- `npm run lint` *(fails: ENOENT: no such file or directory, scandir 'eslint-internal-rules')*
- `npm run typecheck` *(fails: Parameter 'err' implicitly has an 'any' type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a742846ebc832f9995d530ae8f0e5c