### PR TITLE
Add motor detail view and related components

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/interfaces/motor.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/interfaces/motor.ts
@@ -49,6 +49,7 @@ export interface Motor {
     marca: string
     tipo_o_referencia: string
     precio_de_venta: number
+    [key: string]: any
   }
   status: string
   categories: { name: string }[]

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[id].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[id].vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useApi } from '@/composables/useApi'
+import { createUrl } from '@/@core/composable/createUrl'
+import type { Motor } from '@/interfaces/motor'
+import ProductImage from './components/ProductImage.vue'
+import ProductDetails from './components/ProductDetails.vue'
+import ProductDocs from './components/ProductDocs.vue'
+import RelatedProducts from './components/RelatedProducts.vue'
+
+const route = useRoute()
+const id = route.params.id as string
+
+const { data, isFetching } = await useApi<any>(
+  createUrl(`/wp-json/motorlan/v1/motors/${id}`)
+).get().json()
+
+const motor = computed(() => data.value?.data as Motor | undefined)
+</script>
+
+<template>
+  <div v-if="motor" class="motor-detail">
+    <div class="d-flex flex-wrap gap-6 mb-8">
+      <ProductImage :motor="motor" />
+      <ProductDetails :motor="motor" />
+    </div>
+    <ProductDocs :docs="motor.acf?.documentacion" class="mb-8" />
+    <RelatedProducts :current-id="motor.id" />
+  </div>
+  <div v-else-if="isFetching" class="text-center pa-12">
+    <VProgressCircular indeterminate size="64" />
+  </div>
+  <VCard v-else class="pa-8 text-center">
+    <VCardText>Motor no encontrado</VCardText>
+  </VCard>
+</template>
+
+<style scoped>
+.motor-detail {
+  max-width: 1200px;
+  margin-inline: auto;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import type { Motor } from '@/interfaces/motor'
+
+defineProps<{ motor: Motor }>()
+</script>
+
+<template>
+  <div class="product-details flex-grow-1">
+    <h1 class="text-error mb-2">{{ motor.title }}</h1>
+    <div class="text-h5 text-error mb-6">
+      {{ motor.acf.precio_de_venta ? motor.acf.precio_de_venta + ' €' : 'Consultar precio' }}
+    </div>
+    <VTable class="mb-6">
+      <tbody>
+        <tr>
+          <td class="font-weight-medium">Marca</td>
+          <td>{{ motor.acf.marca }}</td>
+        </tr>
+        <tr>
+          <td class="font-weight-medium">Tipo/Modelo</td>
+          <td>{{ motor.acf.tipo_o_referencia }}</td>
+        </tr>
+      </tbody>
+    </VTable>
+  </div>
+</template>
+
+<style scoped>
+.product-details h1 {
+  font-size: 24px;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDocs.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDocs.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+interface Doc { title: string; url: string }
+
+defineProps<{ docs?: Doc[] }>()
+</script>
+
+<template>
+  <div v-if="docs && docs.length" class="product-docs">
+    <h3 class="text-error mb-4">Documentación adicional</h3>
+    <ul>
+      <li v-for="doc in docs" :key="doc.url">
+        <a :href="doc.url" target="_blank">{{ doc.title }}</a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.product-docs ul {
+  list-style: none;
+  padding: 0;
+}
+.product-docs li + li {
+  margin-top: 8px;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductImage.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductImage.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { Motor } from '@/interfaces/motor'
+
+defineProps<{ motor: Motor }>()
+</script>
+
+<template>
+  <div class="product-image">
+    <img :src="motor.imagen_destacada?.url || '/placeholder.png'" alt="" />
+  </div>
+</template>
+
+<style scoped>
+.product-image {
+  flex: 1 1 300px;
+  max-width: 600px;
+  background: #EEF1F4;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+}
+.product-image img {
+  max-width: 100%;
+  max-height: 100%;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/RelatedProducts.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/RelatedProducts.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useApi } from '@/composables/useApi'
+import { createUrl } from '@/@core/composable/createUrl'
+import type { Motor } from '@/interfaces/motor'
+
+const props = defineProps<{ currentId: number }>()
+
+const { data } = await useApi<any>(
+  createUrl('/wp-json/motorlan/v1/motors', { query: { per_page: 4 } })
+).get().json()
+
+const products = computed(() => (data.value?.data || []).filter((m: Motor) => m.id !== props.currentId))
+</script>
+
+<template>
+  <div class="related-products" v-if="products.length">
+    <h3 class="text-error mb-4">Productos relacionados</h3>
+    <VRow>
+      <VCol v-for="motor in products" :key="motor.id" cols="12" sm="6" md="3">
+        <div class="motor-card pa-4">
+          <div class="motor-image mb-4">
+            <img :src="motor.imagen_destacada?.url || '/placeholder.png'" alt="" />
+          </div>
+          <div class="text-error text-body-1 mb-4">{{ motor.title }}</div>
+          <VBtn color="error" class="rounded-pill px-6" :to="'/tienda/' + motor.id">+ INFO</VBtn>
+        </div>
+      </VCol>
+    </VRow>
+  </div>
+</template>
+
+<style scoped>
+.related-products .motor-card {
+  background: #fff;
+  border-radius: 16px;
+}
+.related-products .motor-image {
+  height: 135px;
+  border-radius: 8px;
+  background: #EEF1F4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.related-products .motor-image img {
+  max-width: 100%;
+  max-height: 100%;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
@@ -108,7 +108,13 @@ const totalPages = computed(() => motorsData.value?.pagination.totalPages || 1);
               {{ motor.title }}
             </div>
             <div class="d-flex justify-space-between align-center">
-              <VBtn color="error" class="rounded-pill px-6">+ INFO</VBtn>
+              <VBtn
+                color="error"
+                class="rounded-pill px-6"
+                :to="'/tienda/' + motor.id"
+              >
+                + INFO
+              </VBtn>
               <div class="price text-error font-weight-bold">
                 {{ motor.acf.precio_de_venta ? `${motor.acf.precio_de_venta} €` : 'Consultar precio' }}
               </div>


### PR DESCRIPTION
## Summary
- add dynamic motor detail view under `/tienda/:id`
- create components for motor image, details, documentation, and related products
- wire `+ INFO` button in store to navigate to detail view
- extend motor interface to allow extra ACF fields

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ENOENT: no such file or directory, scandir 'eslint-internal-rules')

------
https://chatgpt.com/codex/tasks/task_e_68a7480dcec8832f8ba4add8e8eb50a1