### PR TITLE
Fix motor detail page data fetching.

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
@@ -13,10 +13,10 @@ const route = useRoute()
 const slug = route.params.slug as string
 
 const { data, isFetching } = await useApi<any>(
-  createUrl('/wp-json/motorlan/v1/motors', { query: { slug } })
+  createUrl(`/wp-json/motorlan/v1/motor/${slug}`),
 ).get().json()
 
-const motor = computed(() => (data.value?.data?.[0] as Motor | undefined))
+const motor = computed(() => data.value?.data as Motor | undefined)
 </script>
 
 <template>


### PR DESCRIPTION
The motor detail page (`/tienda/[slug]`) was using a list endpoint (`/wp-json/motorlan/v1/motors?slug=...`) to fetch motor data, which is not robust for retrieving a single item.

This change updates the API call to use a direct lookup endpoint (`/wp-json/motorlan/v1/motor/{slug}`), which is designed to fetch a single motor by its slug. The data handling is also updated to expect a single object instead of an array.

This aligns with the approach used for fetching by ID and should resolve the issue where the motor detail page fails to load.