### PR TITLE
Feat: Use standard WP REST API for motor slug lookup

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
@@ -13,10 +13,10 @@ const route = useRoute()
 const slug = route.params.slug as string
 
 const { data, isFetching } = await useApi<any>(
-  createUrl(`/wp-json/motorlan/v1/motor/${slug}`),
+  createUrl('/wp-json/wp/v2/motors', { query: { slug } }),
 ).get().json()
 
-const motor = computed(() => data.value?.data as Motor | undefined)
+const motor = computed(() => (data.value?.[0] as Motor | undefined))
 </script>
 
 <template>


### PR DESCRIPTION
The motor detail page was failing to load data because it was using a custom API endpoint that did not correctly handle searching by slug.

This commit updates the page to use the standard WordPress REST API endpoint (`/wp-json/wp/v2/motors`) to fetch motor data by slug. The data parsing logic has also been updated to match the response format of the standard API.

This change directly follows the user's guidance to "apply the search in WordPress by slug" and should provide a more robust and reliable way to fetch motor data.