### PR TITLE
Feat: Add API route to fetch motor by slug

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
@@ -13,10 +13,10 @@ const route = useRoute()
 const slug = route.params.slug as string
 
 const { data, isFetching } = await useApi<any>(
-  createUrl('/wp-json/wp/v2/motors', { query: { slug } }),
+  createUrl(`/wp-json/motorlan/v1/motor/${slug}`),
 ).get().json()
 
-const motor = computed(() => (data.value?.[0] as Motor | undefined))
+const motor = computed(() => data.value?.data as Motor | undefined)
 </script>
 
 <template>


### PR DESCRIPTION
The motor detail page was not working because there was no API endpoint to fetch a single motor by its slug.

This commit introduces a new custom REST API endpoint in `motor-routes.php`:
- `GET /motorlan/v1/motor/{slug}`

This endpoint allows for direct lookup of a motor by its slug.

The Vue component for the motor detail page (`[slug].vue`) has been updated to use this new, more specific endpoint. This resolves the issue and makes the detail page functional.