### PR TITLE
feat: add motor detail template

### DIFF
--- a/wp-content/themes/generatepress-child/functions.php
+++ b/wp-content/themes/generatepress-child/functions.php
@@ -16,3 +16,30 @@ add_filter( 'locale_stylesheet_uri', 'chld_thm_cfg_locale_css' );
 
 // END ENQUEUE PARENT ACTION
 add_filter('use_block_editor_for_post', '__return_false', 10);
+
+// Enqueue gallery assets for motor detail template
+function motorlan_enqueue_motor_detail_assets() {
+    if (is_singular('motor')) {
+        wp_enqueue_style(
+            'lightgallery',
+            'https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/css/lightgallery-bundle.min.css',
+            array(),
+            '2.7.1'
+        );
+        wp_enqueue_script(
+            'lightgallery',
+            'https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/lightgallery.umd.min.js',
+            array(),
+            '2.7.1',
+            true
+        );
+        wp_enqueue_script(
+            'lightgallery-thumbnail',
+            'https://cdn.jsdelivr.net/npm/lightgallery@2.7.1/plugins/thumbnail/lg-thumbnail.umd.min.js',
+            array('lightgallery'),
+            '2.7.1',
+            true
+        );
+    }
+}
+add_action('wp_enqueue_scripts', 'motorlan_enqueue_motor_detail_assets');

--- a/wp-content/themes/generatepress-child/single-motor.php
+++ b/wp-content/themes/generatepress-child/single-motor.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Template for displaying single Motor posts
+ */
+get_header();
+
+// Gather ACF fields
+$tipo       = get_field('tipo_o_referencia');
+$potencia   = get_field('potencia');
+$velocidad  = get_field('velocidad');
+$marca      = get_field('marca');
+$precio     = get_field('precio_de_venta');
+$imagen     = get_field('motor_image');
+$galeria    = get_field('motor_gallery');
+$documento  = get_field('informe_de_reparacion');
+?>
+
+<main class="motor-detail container">
+  <section class="motor-top">
+    <div id="motor-gallery" class="motor-gallery">
+      <?php if( $imagen ): ?>
+        <a href="<?php echo esc_url($imagen['url']); ?>">
+          <img src="<?php echo esc_url($imagen['url']); ?>" alt="<?php the_title_attribute(); ?>" />
+        </a>
+      <?php endif; ?>
+      <?php if( $galeria ):
+        foreach( $galeria as $img ): ?>
+          <a href="<?php echo esc_url($img['url']); ?>">
+            <img src="<?php echo esc_url($img['url']); ?>" alt="<?php the_title_attribute(); ?>" />
+          </a>
+        <?php endforeach;
+      endif; ?>
+    </div>
+
+    <div class="motor-info-card">
+      <h1 class="motor-title"><?php echo esc_html( get_the_title() ); ?></h1>
+      <p class="motor-meta">
+        <?php echo esc_html( trim("$tipo $potencia $velocidad") ); ?>
+      </p>
+      <?php if( $precio ): ?>
+        <p class="motor-price"><?php echo esc_html( $precio ); ?>€</p>
+      <?php endif; ?>
+      <div class="motor-actions">
+        <button class="buy">Comprar</button>
+        <button class="offer">Hacer una oferta</button>
+      </div>
+
+      <div class="contact-form">
+        <h2>Contactar ahora</h2>
+        <form>
+          <textarea name="mensaje" placeholder="Mensaje"></textarea>
+          <input type="text" name="nombre" placeholder="Nombre" />
+          <input type="email" name="email" placeholder="Email" />
+          <input type="tel" name="telefono" placeholder="Teléfono" />
+          <button type="submit">Enviar</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <section class="motor-info-table">
+    <h2>Información del motor</h2>
+    <table>
+      <tbody>
+        <?php if( $marca ): ?>
+        <tr><th>Marca</th><td><?php echo esc_html($marca); ?></td></tr>
+        <?php endif; ?>
+        <?php if( $tipo ): ?>
+        <tr><th>Tipo</th><td><?php echo esc_html($tipo); ?></td></tr>
+        <?php endif; ?>
+        <?php if( $potencia ): ?>
+        <tr><th>Potencia</th><td><?php echo esc_html($potencia); ?></td></tr>
+        <?php endif; ?>
+        <?php if( $velocidad ): ?>
+        <tr><th>Velocidad</th><td><?php echo esc_html($velocidad); ?></td></tr>
+        <?php endif; ?>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="motor-docs">
+    <h2>Documentación adicional</h2>
+    <?php if( $documento ): ?>
+      <a href="<?php echo esc_url($documento['url']); ?>" target="_blank">Descargar informe</a>
+    <?php else: ?>
+      <p>No hay documentación disponible.</p>
+    <?php endif; ?>
+  </section>
+
+  <section class="motor-related">
+    <h2>Productos relacionados</h2>
+    <div class="related-products">
+    <?php
+    $related_query = new WP_Query( array(
+      'post_type'      => 'motor',
+      'posts_per_page' => 4,
+      'post__not_in'   => array( get_the_ID() ),
+    ) );
+    if ( $related_query->have_posts() ):
+      while( $related_query->have_posts() ): $related_query->the_post();
+        $thumb = get_field('motor_image');
+        $price = get_field('precio_de_venta');
+    ?>
+      <article class="product">
+        <a href="<?php the_permalink(); ?>">
+          <?php if( $thumb ): ?>
+            <img src="<?php echo esc_url( $thumb['sizes']['medium'] ); ?>" alt="<?php the_title_attribute(); ?>" />
+          <?php endif; ?>
+          <h3><?php the_title(); ?></h3>
+          <?php if( $price ): ?><span class="price"><?php echo esc_html($price); ?>€</span><?php endif; ?>
+        </a>
+      </article>
+    <?php
+      endwhile;
+      wp_reset_postdata();
+    endif;
+    ?>
+    </div>
+  </section>
+</main>
+
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  const gallery = document.getElementById('motor-gallery');
+  if (gallery && typeof lightGallery === 'function') {
+    lightGallery(gallery, { thumbnail: true });
+  }
+});
+</script>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/generatepress-child/style.css
+++ b/wp-content/themes/generatepress-child/style.css
@@ -11,3 +11,17 @@ Updated: 2025-08-14 20:51:42
 
 */
 
+/* Motor detail template styles */
+.motor-detail { display: flex; flex-direction: column; gap: 2rem; }
+.motor-top { display: flex; flex-wrap: wrap; gap: 2rem; }
+.motor-gallery { flex: 1 1 60%; }
+.motor-info-card { flex: 1 1 35%; }
+.motor-gallery a { display: block; margin-bottom: 0.5rem; }
+.motor-gallery img { width: 100%; height: auto; display: block; }
+.motor-actions { display: flex; gap: 0.5rem; margin: 1rem 0; }
+.motor-info-table table { width: 100%; border-collapse: collapse; }
+.motor-info-table th { text-align: left; padding-right: 1rem; }
+.motor-docs, .motor-info-table, .motor-related { margin-top: 2rem; }
+.related-products { display: flex; flex-wrap: wrap; gap: 1rem; }
+.related-products .product { width: calc(25% - 1rem); box-sizing: border-box; }
+.related-products img { width: 100%; height: auto; display: block; }


### PR DESCRIPTION
## Summary
- add single-motor template with gallery, contact form and related products
- enqueue LightGallery assets for motor pages
- style motor detail layout

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `php -l wp-content/themes/generatepress-child/single-motor.php`


------
https://chatgpt.com/codex/tasks/task_e_68a760961380832f93711803e3403797