### PR TITLE
feat: rework motor detail layout with gallery

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { useApi } from '@/composables/useApi'
-import { createUrl } from '@/@core/composable/createUrl'
-import type { Motor } from '@/interfaces/motor'
 import ProductImage from './components/ProductImage.vue'
 import ProductDetails from './components/ProductDetails.vue'
+import MotorInfo from './components/MotorInfo.vue'
 import ProductDocs from './components/ProductDocs.vue'
 import RelatedProducts from './components/RelatedProducts.vue'
+import type { Motor } from '@/interfaces/motor'
+import { createUrl } from '@/@core/composable/createUrl'
+import { useApi } from '@/composables/useApi'
 
 const route = useRoute()
 const slug = route.params.slug as string
@@ -17,21 +18,47 @@ const { data, isFetching } = await useApi<any>(
 ).get().json()
 
 const motor = computed(() => data.value?.data as Motor | undefined)
+
+const docs = computed(() => {
+  const raw = motor.value?.acf?.documentacion || motor.value?.acf?.documentacion_adjunta
+  if (!raw)
+    return []
+  const arr = Array.isArray(raw) ? raw : [raw]
+
+  return arr
+    .filter((d: any) => d && d.url)
+    .map((d: any) => ({ title: d.title || 'Documento', url: d.url }))
+})
 </script>
 
 <template>
-  <div v-if="motor" class="motor-detail">
+  <div
+    v-if="motor"
+    class="motor-detail"
+  >
     <div class="d-flex flex-wrap gap-6 mb-8">
       <ProductImage :motor="motor" />
       <ProductDetails :motor="motor" />
     </div>
-    <ProductDocs :docs="motor.acf?.documentacion" class="mb-8" />
+    <div class="d-flex flex-wrap gap-6 mb-8">
+      <MotorInfo :motor="motor" />
+      <ProductDocs :docs="docs" />
+    </div>
     <RelatedProducts :current-id="motor.id" />
   </div>
-  <div v-else-if="isFetching" class="text-center pa-12">
-    <VProgressCircular indeterminate size="64" />
+  <div
+    v-else-if="isFetching"
+    class="text-center pa-12"
+  >
+    <VProgressCircular
+      indeterminate
+      size="64"
+    />
   </div>
-  <VCard v-else class="pa-8 text-center">
+  <VCard
+    v-else
+    class="pa-8 text-center"
+  >
     <VCardText>Motor no encontrado</VCardText>
   </VCard>
 </template>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/MotorInfo.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/MotorInfo.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import type { Motor } from '@/interfaces/motor'
+
+defineProps<{ motor: Motor }>()
+</script>
+
+<template>
+  <div class="motor-info">
+    <h3 class="text-error mb-4">
+      Información del motor
+    </h3>
+    <VTable>
+      <tbody>
+        <tr>
+          <td class="font-weight-medium">
+            Marca
+          </td>
+          <td>{{ motor.acf.marca?.name || motor.acf.marca || '-' }}</td>
+        </tr>
+        <tr>
+          <td class="font-weight-medium">
+            Potencia
+          </td>
+          <td>{{ motor.acf.potencia ? `${motor.acf.potencia} kW` : '-' }}</td>
+        </tr>
+        <tr>
+          <td class="font-weight-medium">
+            Velocidad
+          </td>
+          <td>{{ motor.acf.velocidad ? `${motor.acf.velocidad} rpm` : '-' }}</td>
+        </tr>
+        <tr>
+          <td class="font-weight-medium">
+            Par nominal
+          </td>
+          <td>{{ motor.acf.par_nominal ? `${motor.acf.par_nominal} Nm` : '-' }}</td>
+        </tr>
+        <tr>
+          <td class="font-weight-medium">
+            Voltaje
+          </td>
+          <td>{{ motor.acf.voltaje ? `${motor.acf.voltaje} V` : '-' }}</td>
+        </tr>
+        <tr>
+          <td class="font-weight-medium">
+            Intensidad
+          </td>
+          <td>{{ motor.acf.intensidad ? `${motor.acf.intensidad} A` : '-' }}</td>
+        </tr>
+      </tbody>
+    </VTable>
+  </div>
+</template>
+
+<style scoped>
+.motor-info {
+  flex: 1 1 300px;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
@@ -1,32 +1,104 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import type { Motor } from '@/interfaces/motor'
 
-defineProps<{ motor: Motor }>()
+const props = defineProps<{ motor: Motor }>()
+
+const title = computed(() => {
+  const parts = [
+    props.motor.title,
+    props.motor.acf.tipo_o_referencia,
+    props.motor.acf.potencia ? `${props.motor.acf.potencia} kW` : null,
+    props.motor.acf.velocidad ? `${props.motor.acf.velocidad} rpm` : null,
+  ].filter(Boolean)
+
+  return parts.join(' ')
+})
+
+const form = ref({
+  message: '',
+  name: '',
+  email: '',
+  phone: '',
+})
 </script>
 
 <template>
   <div class="product-details flex-grow-1">
-    <h1 class="text-error mb-2">{{ motor.title }}</h1>
-    <div class="text-h5 text-error mb-6">
-      {{ motor.acf.precio_de_venta ? motor.acf.precio_de_venta + ' €' : 'Consultar precio' }}
+    <div class="d-flex justify-space-between align-start mb-4">
+      <h1 class="text-error">
+        {{ title }}
+      </h1>
+      <div class="text-h5 text-error">
+        {{ motor.acf.precio_de_venta ? `${motor.acf.precio_de_venta} €` : 'Consultar precio' }}
+      </div>
     </div>
-    <VTable class="mb-6">
-      <tbody>
-        <tr>
-          <td class="font-weight-medium">Marca</td>
-          <td>{{ motor.acf.marca }}</td>
-        </tr>
-        <tr>
-          <td class="font-weight-medium">Tipo/Modelo</td>
-          <td>{{ motor.acf.tipo_o_referencia }}</td>
-        </tr>
-      </tbody>
-    </VTable>
+    <div class="d-flex flex-wrap gap-4 mb-6">
+      <VBtn
+        color="error"
+        class="rounded-pill px-6 flex-grow-1"
+      >
+        Comprar
+      </VBtn>
+      <VBtn
+        variant="outlined"
+        color="error"
+        class="rounded-pill px-6 flex-grow-1"
+      >
+        Hacer una oferta
+      </VBtn>
+      <div class="d-flex align-center gap-2">
+        <VBtn
+          icon="mdi-facebook"
+          variant="text"
+          color="error"
+        />
+        <VBtn
+          icon="mdi-share-variant"
+          variant="text"
+          color="error"
+        />
+      </div>
+    </div>
+    <div class="contact-card pa-4">
+      <h3 class="text-error mb-4">
+        Contactar ahora
+      </h3>
+      <VForm class="d-flex flex-column gap-4">
+        <VTextarea
+          v-model="form.message"
+          label="Mensaje"
+          rows="3"
+        />
+        <VTextField
+          v-model="form.name"
+          label="Nombre"
+        />
+        <VTextField
+          v-model="form.email"
+          label="Email"
+        />
+        <VTextField
+          v-model="form.phone"
+          label="Teléfono"
+        />
+        <VBtn
+          color="error"
+          class="rounded-pill align-self-start"
+        >
+          Enviar
+        </VBtn>
+      </VForm>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .product-details h1 {
   font-size: 24px;
+}
+.contact-card {
+  border: 1px solid #E6E6E6;
+  border-radius: 8px;
 }
 </style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDocs.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDocs.vue
@@ -5,17 +5,32 @@ defineProps<{ docs?: Doc[] }>()
 </script>
 
 <template>
-  <div v-if="docs && docs.length" class="product-docs">
-    <h3 class="text-error mb-4">Documentación adicional</h3>
+  <div
+    v-if="docs && docs.length"
+    class="product-docs"
+  >
+    <h3 class="text-error mb-4">
+      Documentación adicional
+    </h3>
     <ul>
-      <li v-for="doc in docs" :key="doc.url">
-        <a :href="doc.url" target="_blank">{{ doc.title }}</a>
+      <li
+        v-for="doc in docs"
+        :key="doc.url"
+      >
+        <a
+          :href="doc.url"
+          target="_blank"
+        >{{ doc.title }}</a>
       </li>
     </ul>
   </div>
 </template>
 
 <style scoped>
+.product-docs {
+  flex: 1 1 300px;
+}
+
 .product-docs ul {
   list-style: none;
   padding: 0;

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductImage.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductImage.vue
@@ -1,19 +1,73 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { register } from 'swiper/element/bundle'
 import type { Motor } from '@/interfaces/motor'
 
-defineProps<{ motor: Motor }>()
+const props = defineProps<{ motor: Motor }>()
+
+register()
+
+const images = computed(() => {
+  const gallery = (props.motor.acf?.motor_gallery || []) as any[]
+
+  const featured = props.motor.imagen_destacada && !Array.isArray(props.motor.imagen_destacada)
+    ? [props.motor.imagen_destacada]
+    : []
+
+  return [...featured, ...gallery].filter(img => img && img.url)
+})
 </script>
 
 <template>
   <div class="product-image">
-    <img :src="motor.imagen_destacada?.url || '/placeholder.png'" alt="" />
+    <swiper-container
+      v-if="images.length"
+      class="mainSwiper"
+      thumbs-swiper=".thumbsSwiper"
+      loop="true"
+      navigation="true"
+      space-between="10"
+    >
+      <swiper-slide
+        v-for="img in images"
+        :key="img.url"
+      >
+        <img
+          :src="img.url"
+          alt=""
+        >
+      </swiper-slide>
+    </swiper-container>
+    <swiper-container
+      v-if="images.length > 1"
+      class="thumbsSwiper mt-2"
+      loop="true"
+      free-mode="true"
+      slides-per-view="4"
+      space-between="10"
+    >
+      <swiper-slide
+        v-for="img in images"
+        :key="`thumb-${img.url}`"
+      >
+        <img
+          :src="img.url"
+          alt=""
+        >
+      </swiper-slide>
+    </swiper-container>
   </div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
+@use "swiper/css/bundle";
+
 .product-image {
   flex: 1 1 300px;
   max-width: 600px;
+}
+
+.product-image swiper-container {
   background: #EEF1F4;
   border-radius: 8px;
   display: flex;
@@ -21,8 +75,20 @@ defineProps<{ motor: Motor }>()
   justify-content: center;
   min-height: 300px;
 }
+
 .product-image img {
   max-width: 100%;
   max-height: 100%;
+}
+
+.thumbsSwiper {
+  swiper-slide {
+    opacity: 0.5;
+    cursor: pointer;
+  }
+
+  .swiper-slide-thumb-active {
+    opacity: 1;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- add swiper gallery for motor images
- include contact form and action buttons in product details
- show detailed motor specs and docs side by side

## Testing
- `npm run lint` *(fails: Definition for rule 'valid-appcardcode-demo-sfc' was not found)*
- `npm run typecheck` *(fails: Cannot find module '@db/pages/profile/types')*


------
https://chatgpt.com/codex/tasks/task_e_68a76260333c832fb130a0c3e9a5ad2d