### PR TITLE
Add purchase flow with rating in Vue app

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 import type { Motor } from '@/interfaces/motor'
 
 const props = defineProps<{ motor: Motor }>()
 
 
+
+const router = useRouter()
 
 const form = ref({
   message: '',
@@ -12,6 +15,22 @@ const form = ref({
   email: '',
   phone: '',
 })
+
+const buyMotor = async () => {
+  if (!confirm('¿Confirmar compra?'))
+    return
+
+  try {
+    const res = await $api('/wp-json/motorlan/v1/purchases', {
+      method: 'POST',
+      body: { motor_id: props.motor.id },
+    })
+    router.push(`/tienda/compra/${res.uuid}`)
+  }
+  catch (error) {
+    console.error(error)
+  }
+}
 </script>
 
 <template>
@@ -21,6 +40,7 @@ const form = ref({
       <VBtn
         color="error"
         class="rounded-pill px-6 flex-grow-1"
+        @click="buyMotor"
       >
         Comprar
       </VBtn>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/compra/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/compra/[uuid].vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { createUrl } from '@/@core/composable/createUrl'
+import { useApi } from '@/composables/useApi'
+
+const route = useRoute()
+const uuid = route.params.uuid as string
+
+const { data } = await useApi<any>(createUrl(`/wp-json/motorlan/v1/purchases/${uuid}`)).get().json()
+const purchase = computed(() => data.value?.data)
+
+const opinion = ref({ valoracion: 0, comentario: '' })
+
+const sendOpinion = async () => {
+  try {
+    await $api(`/wp-json/motorlan/v1/purchases/${uuid}/opinion`, {
+      method: 'POST',
+      body: opinion.value,
+    })
+    opinion.value = { valoracion: 0, comentario: '' }
+  }
+  catch (error) {
+    console.error(error)
+  }
+}
+</script>
+
+<template>
+  <VContainer v-if="purchase" fluid>
+    <VCard class="mb-6">
+      <VCardTitle>Detalle de la compra</VCardTitle>
+      <VCardText>
+        <div class="d-flex justify-space-between">
+          <div>
+            <div class="text-h6">{{ purchase.motor?.title }}</div>
+            <div>{{ purchase.fecha_compra }}</div>
+            <div>Estado: {{ purchase.estado }}</div>
+          </div>
+          <div class="text-h6">
+            {{ purchase.motor?.acf?.precio_de_venta ? `${purchase.motor.acf.precio_de_venta} €` : '' }}
+          </div>
+        </div>
+      </VCardText>
+    </VCard>
+
+    <VCard>
+      <VCardTitle>¿Qué te pareció tu producto?</VCardTitle>
+      <VCardText>
+        <VRating v-model="opinion.valoracion" class="mb-4" />
+        <VTextarea v-model="opinion.comentario" label="Comentario" rows="3" />
+        <VBtn color="error" class="mt-4" @click="sendOpinion">Enviar</VBtn>
+      </VCardText>
+    </VCard>
+  </VContainer>
+</template>


### PR DESCRIPTION
## Summary
- generate UUID for each purchase and store motor, seller, buyer, status
- expose purchase endpoints that resolve by UUID
- consume UUID in Vue pages and show purchase status

## Testing
- `npm run lint` *(fails: ENOENT no such file or directory, scandir '/workspace/dev.motorlan/wp-content/plugins/motorlan-api-vue/app/eslint-internal-rules')*
- `npm run typecheck` *(fails: TS7006 Parameter 'err' implicitly has an 'any' type, TS2307 Cannot find module '@db/pages/profile/types', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a89dc8e54c832f9f56af322609ba08