### PR TITLE
Add motor description and Q&A section

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
@@ -6,6 +6,7 @@ import ProductDetails from './components/ProductDetails.vue'
 import MotorInfo from './components/MotorInfo.vue'
 import ProductDocs from './components/ProductDocs.vue'
 import RelatedProducts from './components/RelatedProducts.vue'
+import MotorQuestions from './components/MotorQuestions.vue'
 import type { Motor } from '@/interfaces/motor'
 import { createUrl } from '@/@core/composable/createUrl'
 import { useApi } from '@/composables/useApi'
@@ -80,6 +81,7 @@ const title = computed(() => {
     </div>
 
     <RelatedProducts :current-id="motor.id" />
+    <MotorQuestions :motor-id="motor.id" />
   </VContainer>
 
   <div

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/MotorQuestions.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/MotorQuestions.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { createUrl } from '@/@core/composable/createUrl'
+import { useApi } from '@/composables/useApi'
+
+const props = defineProps<{ motorId: number }>()
+
+const newQuestion = ref('')
+const questions = ref<any[]>([])
+const loading = ref(false)
+
+const fetchQuestions = async () => {
+  try {
+    const { data } = await useApi<any>(
+      createUrl(`/wp-json/motorlan/v1/motors/${props.motorId}/questions`),
+    ).get().json()
+    questions.value = data.value?.data || []
+  }
+  catch (error) {
+    console.error(error)
+  }
+}
+
+const submitQuestion = async () => {
+  if (!newQuestion.value)
+    return
+  loading.value = true
+  try {
+    await useApi(
+      createUrl(`/wp-json/motorlan/v1/motors/${props.motorId}/questions`),
+    ).post({ body: { pregunta: newQuestion.value } })
+    newQuestion.value = ''
+    await fetchQuestions()
+  }
+  catch (error) {
+    console.error(error)
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchQuestions)
+</script>
+
+<template>
+  <div class="motor-questions mt-8">
+    <h2 class="text-h5 mb-4">Preguntas y respuestas</h2>
+    <VForm
+      class="d-flex align-center gap-4 mb-6"
+      @submit.prevent="submitQuestion"
+    >
+      <VTextField
+        v-model="newQuestion"
+        label="Escribe tu pregunta..."
+        class="flex-grow-1"
+      />
+      <VBtn
+        color="primary"
+        type="submit"
+        :loading="loading"
+      >
+        Preguntar
+      </VBtn>
+    </VForm>
+
+    <div v-if="questions.length">
+      <div
+        v-for="q in questions"
+        :key="q.id"
+        class="mb-4"
+      >
+        <p class="mb-1 font-weight-medium">{{ q.pregunta }}</p>
+        <p v-if="q.respuesta" class="text-secondary">
+          {{ q.respuesta }}
+        </p>
+      </div>
+    </div>
+    <div v-else class="text-body-2">
+      No hay preguntas todavía.
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.motor-questions {
+  border-top: 1px solid #E6E6E6;
+  padding-top: 1rem;
+}
+</style>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
@@ -50,12 +50,6 @@ const share = () => {
 
 const router = useRouter()
 
-const form = ref({
-  message: '',
-  name: '',
-  email: '',
-  phone: '',
-})
 
 const buyMotor = async () => {
   if (!confirm('¿Confirmar compra?'))
@@ -117,6 +111,7 @@ const buyMotor = async () => {
         Hacer una oferta
       </VBtn>
     </div>
+    <!--
     <div class="contact-card pa-4">
       <h3 class="mb-4">
         Contactar ahora
@@ -146,6 +141,14 @@ const buyMotor = async () => {
           Enviar
         </VBtn>
       </VForm>
+    </div>
+    -->
+
+    <div class="contact-card pa-4">
+      <h3 class="mb-4">
+        Descripción
+      </h3>
+      <p v-html="props.motor.acf.descripcion" />
     </div>
   </div>
 </template>

--- a/wp-content/plugins/motorlan-api-vue/includes/api/questions-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/questions-routes.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * REST API routes for motor questions.
+ *
+ * @package motorlan-api-vue
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+function motorlan_register_question_rest_routes() {
+    $namespace = 'motorlan/v1';
+
+    register_rest_route( $namespace, '/motors/(?P<motor_id>\\d+)/questions', array(
+        array(
+            'methods'  => WP_REST_Server::READABLE,
+            'callback' => 'motorlan_get_questions_callback',
+            'permission_callback' => '__return_true',
+        ),
+        array(
+            'methods'  => WP_REST_Server::CREATABLE,
+            'callback' => 'motorlan_create_question_callback',
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ),
+    ) );
+
+    register_rest_route( $namespace, '/questions/(?P<id>\\d+)/answer', array(
+        'methods'  => WP_REST_Server::CREATABLE,
+        'callback' => 'motorlan_answer_question_callback',
+        'permission_callback' => function ( WP_REST_Request $request ) {
+            $question_id = (int) $request['id'];
+            $motor_id    = (int) get_field( 'motor', $question_id );
+            $motor_post  = get_post( $motor_id );
+            $current_user = get_current_user_id();
+
+            if ( ! $motor_post ) {
+                return false;
+            }
+
+            return (int) $motor_post->post_author === $current_user || current_user_can( 'edit_posts' );
+        },
+    ) );
+}
+add_action( 'rest_api_init', 'motorlan_register_question_rest_routes' );
+
+function motorlan_get_questions_callback( WP_REST_Request $request ) {
+    $motor_id = (int) $request['motor_id'];
+
+    $args = array(
+        'post_type'      => 'pregunta',
+        'posts_per_page' => -1,
+        'meta_query'     => array(
+            array(
+                'key'   => 'motor',
+                'value' => $motor_id,
+            ),
+        ),
+    );
+
+    $query = new WP_Query( $args );
+    $questions = array();
+
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $qid = get_the_ID();
+            $questions[] = array(
+                'id'       => $qid,
+                'pregunta' => get_field( 'pregunta', $qid ),
+                'respuesta'=> get_field( 'respuesta', $qid ),
+            );
+        }
+        wp_reset_postdata();
+    }
+
+    return new WP_REST_Response( array( 'data' => $questions ), 200 );
+}
+
+function motorlan_create_question_callback( WP_REST_Request $request ) {
+    $motor_id = (int) $request['motor_id'];
+    $user_id  = get_current_user_id();
+    $pregunta = sanitize_text_field( $request->get_param( 'pregunta' ) );
+
+    $post_id = wp_insert_post( array(
+        'post_type'   => 'pregunta',
+        'post_status' => 'publish',
+        'post_title'  => wp_trim_words( $pregunta, 8, '...' ),
+    ) );
+
+    if ( is_wp_error( $post_id ) ) {
+        return new WP_Error( 'cannot_create', 'Cannot create question', array( 'status' => 500 ) );
+    }
+
+    update_field( 'usuario', $user_id, $post_id );
+    update_field( 'motor', $motor_id, $post_id );
+    update_field( 'pregunta', $pregunta, $post_id );
+
+    return new WP_REST_Response( array( 'success' => true, 'id' => $post_id ), 201 );
+}
+
+function motorlan_answer_question_callback( WP_REST_Request $request ) {
+    $question_id = (int) $request['id'];
+    $respuesta   = sanitize_text_field( $request->get_param( 'respuesta' ) );
+
+    update_field( 'respuesta', $respuesta, $question_id );
+
+    return new WP_REST_Response( array( 'success' => true ), 200 );
+}

--- a/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
+++ b/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
@@ -26,6 +26,7 @@ require_once MOTORLAN_API_VUE_PATH . 'includes/acf-setup.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/acf-setup-purchases.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/motor-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/my-account-routes.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/api/questions-routes.php';
 
 require_once MOTORLAN_API_VUE_PATH . 'includes/admin-mods.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/vue-app-setup.php';


### PR DESCRIPTION
## Summary
- Replace contact form in motor details with motor description
- Introduce Q&A component for motor pages
- Add REST API endpoints for motor questions and answers

## Testing
- `php -l wp-content/plugins/motorlan-api-vue/includes/api/questions-routes.php`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ENOENT: no such file or directory, scandir 'eslint-internal-rules')*


------
https://chatgpt.com/codex/tasks/task_e_68a8a96bc0d8832f846fe4b0a1696937