### PR TITLE
Fix useApi usage when saving motors

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
@@ -78,13 +78,12 @@ onMounted(async () => {
 })
 
 const uploadMedia = async (file: File) => {
-  const api = useApi()
   const formData = new FormData()
 
   formData.append('file', file)
 
   try {
-    const response = await api('/wp-json/wp/v2/media', {
+    const response = await useApi('/wp-json/wp/v2/media', {
       method: 'POST',
       body: formData,
       headers: {
@@ -114,7 +113,6 @@ const handleGalleryImageUpload = async (file: File) => {
 }
 
 const publishMotor = async () => {
-  const api = useApi()
   const url = '/wp-json/wp/v2/motors'
   const method = 'POST'
 
@@ -131,7 +129,7 @@ const publishMotor = async () => {
       }
     }
     console.log('Data to send:', JSON.stringify(motorData.value, null, 2))
-    await api(url, {
+    await useApi(url, {
       method,
       body: motorData.value,
     })

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/edit/[uuid].vue
@@ -142,7 +142,6 @@ const updateMotor = async () => {
     return
   }
 
-  const api = useApi()
   const url = `/wp-json/motorlan/v1/motors/uuid/${motorUuid}`
   const method = 'POST'
 
@@ -198,7 +197,7 @@ const updateMotor = async () => {
     }
 
     console.log('Data to send:', JSON.stringify(motorData.value, null, 2))
-    await api(url, {
+    await useApi(url, {
       method,
       body: motorData.value,
     })


### PR DESCRIPTION
## Summary
- fix edit motor form by using `useApi` correctly
- fix new motor form to avoid `useApi()` path errors during uploads and publishing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ENOENT: no such file or directory, scandir 'eslint-internal-rules')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ceb4ca38832f8076546b37fd02f5