### PR TITLE
feat: Implementar flujo de garantía Motorlan en la creación de motores

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/includes/api/garantia-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/garantia-routes.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Setup for Garantia REST API Routes.
+ *
+ * @package motorlan-api-vue
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Register custom REST API routes for garantias.
+ */
+function motorlan_register_garantia_rest_routes() {
+    $namespace = 'motorlan/v1';
+
+    register_rest_route( $namespace, '/garantias', array(
+        array(
+            'methods'             => WP_REST_Server::CREATABLE,
+            'callback'            => 'motorlan_create_garantia_item',
+            'permission_callback' => function () {
+                return current_user_can( 'edit_posts' );
+            },
+            'args' => array(
+                'motor_id' => array(
+                    'required' => true,
+                    'validate_callback' => function( $param ) {
+                        return is_numeric( $param );
+                    }
+                ),
+                'agencia_transporte' => array(
+                    'required' => true,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ),
+                'modalidad_pago' => array(
+                    'required' => true,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ),
+                 'direccion_motor' => array(
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ),
+                'cp_motor' => array(
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ),
+                'comentarios' => array(
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_textarea_field',
+                ),
+            ),
+        ),
+    ) );
+}
+add_action( 'rest_api_init', 'motorlan_register_garantia_rest_routes' );
+
+/**
+ * Callback to create a new garantia item.
+ *
+ * @param WP_REST_Request $request The request object.
+ * @return WP_REST_Response|WP_Error
+ */
+function motorlan_create_garantia_item( WP_REST_Request $request ) {
+    $params = $request->get_params();
+    $motor_id = intval( $params['motor_id'] );
+
+    // Check if motor exists
+    if ( get_post_status( $motor_id ) === false ) {
+        return new WP_Error( 'motor_not_found', 'El motor especificado no existe.', array( 'status' => 404 ) );
+    }
+
+    $motor_title = get_the_title( $motor_id );
+    $garantia_title = 'Garantía para Motor: ' . $motor_title;
+
+    $new_post_data = array(
+        'post_title'  => $garantia_title,
+        'post_status' => 'publish',
+        'post_type'   => 'garantia',
+        'post_author' => get_current_user_id(),
+    );
+
+    $garantia_id = wp_insert_post( $new_post_data );
+
+    if ( is_wp_error( $garantia_id ) ) {
+        return $garantia_id;
+    }
+
+    // Update meta fields
+    update_post_meta( $garantia_id, 'motor_id', $motor_id );
+
+    if ( isset( $params['agencia_transporte'] ) ) {
+        update_post_meta( $garantia_id, 'agencia_transporte', $params['agencia_transporte'] );
+    }
+    if ( isset( $params['modalidad_pago'] ) ) {
+        update_post_meta( $garantia_id, 'modalidad_pago', $params['modalidad_pago'] );
+    }
+    if ( isset( $params['direccion_motor'] ) ) {
+        update_post_meta( $garantia_id, 'direccion_motor', $params['direccion_motor'] );
+    }
+    if ( isset( $params['cp_motor'] ) ) {
+        update_post_meta( $garantia_id, 'cp_motor', $params['cp_motor'] );
+    }
+    if ( isset( $params['comentarios'] ) ) {
+        update_post_meta( $garantia_id, 'comentarios', $params['comentarios'] );
+    }
+
+    $response_data = array(
+        'message'     => 'Solicitud de garantía creada con éxito.',
+        'garantia_id' => $garantia_id,
+    );
+
+    return new WP_REST_Response( $response_data, 201 );
+}

--- a/wp-content/plugins/motorlan-api-vue/includes/cpt-setup-garantia.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/cpt-setup-garantia.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Setup for Custom Post Type "Garantia".
+ *
+ * @package motorlan-api-vue
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Register a custom post type called "garantia".
+ */
+function motorlan_register_garantia_cpt() {
+    $labels = array(
+        'name'               => _x( 'Garantías', 'post type general name', 'motorlan-api-vue' ),
+        'singular_name'      => _x( 'Garantía', 'post type singular name', 'motorlan-api-vue' ),
+        'menu_name'          => _x( 'Garantías', 'admin menu', 'motorlan-api-vue' ),
+        'name_admin_bar'     => _x( 'Garantía', 'add new on admin bar', 'motorlan-api-vue' ),
+        'add_new'            => _x( 'Añadir Nueva', 'garantia', 'motorlan-api-vue' ),
+        'add_new_item'       => __( 'Añadir Nueva Garantía', 'motorlan-api-vue' ),
+        'new_item'           => __( 'Nueva Garantía', 'motorlan-api-vue' ),
+        'edit_item'          => __( 'Editar Garantía', 'motorlan-api-vue' ),
+        'view_item'          => __( 'Ver Garantía', 'motorlan-api-vue' ),
+        'all_items'          => __( 'Todas las Garantías', 'motorlan-api-vue' ),
+        'search_items'       => __( 'Buscar Garantías', 'motorlan-api-vue' ),
+        'not_found'          => __( 'No se encontraron garantías.', 'motorlan-api-vue' ),
+        'not_found_in_trash' => __( 'No se encontraron garantías en la papelera.', 'motorlan-api-vue' )
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => false,
+        'publicly_queryable' => false,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'query_var'          => false,
+        'rewrite'            => false,
+        'capability_type'    => 'post',
+        'has_archive'        => false,
+        'hierarchical'       => false,
+        'menu_position'      => 6,
+        'supports'           => array( 'title', 'custom-fields' ),
+        'show_in_rest'       => true,
+    );
+
+    register_post_type( 'garantia', $args );
+}
+add_action( 'init', 'motorlan_register_garantia_cpt' );
+
+/**
+ * Register custom meta fields for the 'garantia' post type.
+ */
+function motorlan_register_garantia_meta() {
+    register_post_meta( 'garantia', 'motor_id', array(
+        'show_in_rest' => true,
+        'single' => true,
+        'type' => 'integer',
+    ) );
+    register_post_meta( 'garantia', 'direccion_motor', array(
+        'show_in_rest' => true,
+        'single' => true,
+        'type' => 'string',
+    ) );
+    register_post_meta( 'garantia', 'cp_motor', array(
+        'show_in_rest' => true,
+        'single' => true,
+        'type' => 'string',
+    ) );
+    register_post_meta( 'garantia', 'agencia_transporte', array(
+        'show_in_rest' => true,
+        'single' => true,
+        'type' => 'string',
+    ) );
+    register_post_meta( 'garantia', 'modalidad_pago', array(
+        'show_in_rest' => true,
+        'single' => true,
+        'type' => 'string',
+    ) );
+    register_post_meta( 'garantia', 'comentarios', array(
+        'show_in_rest' => true,
+        'single' => true,
+        'type' => 'string',
+    ) );
+}
+add_action( 'init', 'motorlan_register_garantia_meta' );

--- a/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
+++ b/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
@@ -21,10 +21,12 @@ define( 'MOTORLAN_API_VUE_PATH', plugin_dir_path( __FILE__ ) );
 
 // Include required files
 require_once MOTORLAN_API_VUE_PATH . 'includes/cpt-setup.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/cpt-setup-garantia.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/cpt-setup-purchases.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/acf-setup.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/acf-setup-purchases.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/motor-routes.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/api/garantia-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/my-account-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/questions-routes.php';
 


### PR DESCRIPTION
Este commit introduce un nuevo flujo de varios pasos en el formulario de creación de motores para permitir a los usuarios añadir una Garantía Motorlan.

Principales cambios:

- Se ha refactorizado el formulario de creación de motores en la aplicación Vue (`.../add/index.vue`) para convertirlo en un asistente de 3 pasos:
  1. Creación de los detalles del motor.
  2. Oferta para añadir la Garantía Motorlan (Aceptar/Omitir).
  3. Formulario para los detalles de la garantía.

- Se ha añadido un nuevo Custom Post Type (CPT) 'garantia' en el backend de WordPress para almacenar todas las solicitudes de garantía.

- Se ha creado un nuevo endpoint en la API REST (`/motorlan/v1/garantias`) para gestionar el envío del formulario de garantía desde la aplicación Vue.

- Se ha implementado la lógica de autocompletado para rellenar los datos del usuario (dirección, CP) en el formulario de garantía, mejorando la experiencia de usuario.