### PR TITLE
Fix tienda search bar layout and default sorting

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
@@ -1,50 +1,51 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue';
-import { useApi } from '@/composables/useApi';
-import { createUrl } from '@/@core/composable/createUrl';
-import type { Motor } from '@/interfaces/motor';
+import { computed, onMounted, ref, watch } from 'vue'
+import { useApi } from '@/composables/useApi'
+import { createUrl } from '@/@core/composable/createUrl'
+import type { Motor } from '@/interfaces/motor'
 
 interface Term {
-  id: number;
-  name: string;
-  slug: string;
+  id: number
+  name: string
+  slug: string
 }
 
 // -- State Management --
-const selectedCategory = ref<string | null>(null);
-const selectedBrand = ref<number | null>(null);
-const selectedCountry = ref<string | null>(null);
-const selectedState = ref<string | null>(null);
-const typeModel = ref('');
-const productTypes = ref<string[]>([]);
-const selectedPar = ref<string | null>(null);
-const selectedPotencia = ref<string | null>(null);
-const selectedVelocidad = ref<string | null>(null);
-const searchTerm = ref('');
-const order = ref<string | null>(null);
+const selectedCategory = ref<string | null>(null)
+const selectedBrand = ref<number | null>(null)
+const selectedCountry = ref<string | null>(null)
+const selectedState = ref<string | null>(null)
+const typeModel = ref('')
+const productTypes = ref<string[]>([])
+const selectedPar = ref<string | null>(null)
+const selectedPotencia = ref<string | null>(null)
+const selectedVelocidad = ref<string | null>(null)
+const searchTerm = ref('')
+const order = ref<string>('Recientes')
 
-const parOptions = ['0-50', '50-100'];
-const potenciaOptions = ['0-1 kW', '1-5 kW'];
-const velocidadOptions = ['500 rpm', '1500 rpm'];
-const orderOptions = ['Recientes', 'Precio asc', 'Precio desc'];
+const parOptions = ['0-50', '50-100']
+const potenciaOptions = ['0-1 kW', '1-5 kW']
+const velocidadOptions = ['500 rpm', '1500 rpm']
+const orderOptions = ['Recientes', 'Precio asc', 'Precio desc']
 
-const itemsPerPage = ref(9);
-const page = ref(1);
+const itemsPerPage = ref(9)
+const page = ref(1)
 
 // -- Data Fetching --
-const { data: categoriesData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/motor-categories'));
-const categories = computed(() => categoriesData.value || []);
+const { data: categoriesData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/motor-categories'))
+const categories = computed(() => categoriesData.value || [])
 
-const { data: brandsData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/marcas'));
-const marcas = computed(() => brandsData.value || []);
+const { data: brandsData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/marcas'))
+const marcas = computed(() => brandsData.value || [])
 
 const motorsApiUrl = computed(() => {
-  const baseUrl = '/wp-json/motorlan/v1/motors';
+  const baseUrl = '/wp-json/motorlan/v1/motors'
+
   const sortOptions = {
     'Recientes': { orderby: 'date', order: 'desc' },
     'Precio asc': { orderby: 'price', order: 'asc' },
     'Precio desc': { orderby: 'price', order: 'desc' },
-  };
+  }
 
   const queryParams = {
     per_page: itemsPerPage.value,
@@ -59,62 +60,131 @@ const motorsApiUrl = computed(() => {
     velocidad: selectedVelocidad.value,
     par_nominal: selectedPar.value,
     ...(order.value ? sortOptions[order.value] : {}),
-  };
+  }
 
   const filteredParams = Object.entries(queryParams)
     .filter(([_, value]) => value !== null && value !== undefined && value !== '')
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-    .join('&');
+    .join('&')
 
-  return `${baseUrl}?${filteredParams}`;
-});
+  return `${baseUrl}?${filteredParams}`
+})
 
-const { data: motorsData, isFetching: loading, execute: fetchMotors } = useApi<any>(motorsApiUrl, { immediate: false }).get();
+const { data: motorsData, isFetching: loading, execute: fetchMotors } = useApi<any>(motorsApiUrl, { immediate: false }).get()
 
 watch(
   () => motorsApiUrl.value,
   () => {
-    fetchMotors();
-  }
-);
+    fetchMotors()
+  },
+)
 
-onMounted(fetchMotors);
+onMounted(fetchMotors)
 
-const motors = computed((): Motor[] => motorsData.value?.data || []);
-const totalMotors = computed(() => motorsData.value?.pagination.total || 0);
-const totalPages = computed(() => motorsData.value?.pagination.totalPages || 1);
+const motors = computed((): Motor[] => motorsData.value?.data || [])
+const totalMotors = computed(() => motorsData.value?.pagination.total || 0)
+const totalPages = computed(() => motorsData.value?.pagination.totalPages || 1)
 
 const search = () => {
-  page.value = 1;
-  fetchMotors();
-};
+  page.value = 1
+  fetchMotors()
+}
 </script>
 
 <template>
   <div class="tienda d-flex">
     <aside class="filters pa-4">
       <div class="d-flex align-center mb-2">
-        <VIcon size="18" class="me-2" color="error">mdi-checkbox-blank-outline</VIcon>
+        <VIcon
+          size="18"
+          class="me-2"
+          color="error"
+        >
+          mdi-checkbox-blank-outline
+        </VIcon>
         <span class="text-error font-weight-semibold">FILTROS</span>
       </div>
-      <VDivider thickness="3" class="mb-4" color="error" />
+      <VDivider
+        thickness="3"
+        class="mb-4"
+        color="error"
+      />
 
-      <VTextField v-model="typeModel" label="Tipo / modelo" variant="outlined" density="comfortable" class="mb-6" />
+      <VTextField
+        v-model="typeModel"
+        label="Tipo / modelo"
+        variant="outlined"
+        density="comfortable"
+        class="mb-6"
+      />
 
-      <p class="text-body-2 mb-2">Tipo de producto</p>
-      <VCheckbox v-model="productTypes" label="Motor" value="Motor" density="compact" hide-details />
-      <VCheckbox v-model="productTypes" label="Regulador" value="Regulador" density="compact" hide-details />
-      <VCheckbox v-model="productTypes" label="Otros repuestos" value="Otros repuestos" density="compact" hide-details class="mb-6" />
+      <p class="text-body-2 mb-2">
+        Tipo de producto
+      </p>
+      <VCheckbox
+        v-model="productTypes"
+        label="Motor"
+        value="Motor"
+        density="compact"
+        hide-details
+      />
+      <VCheckbox
+        v-model="productTypes"
+        label="Regulador"
+        value="Regulador"
+        density="compact"
+        hide-details
+      />
+      <VCheckbox
+        v-model="productTypes"
+        label="Otros repuestos"
+        value="Otros repuestos"
+        density="compact"
+        hide-details
+        class="mb-6"
+      />
 
-      <AppSelect v-model="selectedPar" label="PAR (Nm)" :items="parOptions" class="mb-4" clearable />
-      <AppSelect v-model="selectedPotencia" label="Potencia" :items="potenciaOptions" class="mb-4" clearable />
-      <AppSelect v-model="selectedVelocidad" label="Velocidad" :items="velocidadOptions" class="mb-4" clearable />
-      <AppSelect v-model="selectedBrand" label="Marcas" :items="marcas" item-title="name" item-value="id" class="mb-4" clearable />
-      <AppSelect v-model="selectedState" label="Estado" :items="['Nuevo','Usado','Restaurado']" class="mb-4" clearable />
+      <AppSelect
+        v-model="selectedPar"
+        label="PAR (Nm)"
+        :items="parOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-model="selectedPotencia"
+        label="Potencia"
+        :items="potenciaOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-model="selectedVelocidad"
+        label="Velocidad"
+        :items="velocidadOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-model="selectedBrand"
+        label="Marcas"
+        :items="marcas"
+        item-title="name"
+        item-value="id"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-model="selectedState"
+        label="Estado"
+        :items="['Nuevo', 'Usado', 'Restaurado']"
+        class="mb-4"
+        clearable
+      />
     </aside>
 
     <section class="flex-grow-1 ps-6">
-      <div class="d-flex align-center mb-6 gap-4">
+      <div class="top-bar">
         <VTextField
           v-model="searchTerm"
           placeholder="Buscar..."
@@ -123,18 +193,43 @@ const search = () => {
           class="flex-grow-1"
           @keydown.enter="search"
         />
-        <VBtn icon color="error" :loading="loading" @click="search">
-          <VIcon>mdi-magnify</VIcon>
+        <VBtn
+          icon
+          color="error"
+          class="search-btn"
+          :loading="loading"
+          @click="search"
+        >
+          <VIcon color="white">
+            mdi-magnify
+          </VIcon>
         </VBtn>
-        <AppSelect v-model="order" :items="orderOptions" label="Ordenar" clearable style="max-width:220px" />
+        <AppSelect
+          v-model="order"
+          :items="orderOptions"
+          label="Ordenar"
+          clearable
+          style="max-width:220px"
+        />
       </div>
 
-      <div v-if="loading && !motors.length" class="text-center pa-12">
-        <VProgressCircular indeterminate size="64" />
-        <p class="mt-4">Cargando motores...</p>
+      <div
+        v-if="loading && !motors.length"
+        class="text-center pa-12"
+      >
+        <VProgressCircular
+          indeterminate
+          size="64"
+        />
+        <p class="mt-4">
+          Cargando motores...
+        </p>
       </div>
 
-      <VRow v-else-if="motors.length" class="motor-grid">
+      <VRow
+        v-else-if="motors.length"
+        class="motor-grid"
+      >
         <VCol
           v-for="motor in motors"
           :key="motor.id"
@@ -144,7 +239,10 @@ const search = () => {
         >
           <div class="motor-card pa-4">
             <div class="motor-image mb-6">
-              <img :src="motor.imagen_destacada?.url || '/placeholder.png'" alt="" />
+              <img
+                :src="motor.imagen_destacada?.url || '/placeholder.png'"
+                alt=""
+              >
             </div>
             <div class="text-error text-body-1 mb-4">
               {{ motor.title }}
@@ -153,7 +251,7 @@ const search = () => {
               <VBtn
                 color="error"
                 class="rounded-pill px-6"
-                :to="'/tienda/' + motor.slug"
+                :to="`/tienda/${motor.slug}`"
               >
                 + INFO
               </VBtn>
@@ -165,9 +263,14 @@ const search = () => {
         </VCol>
       </VRow>
 
-      <VCard v-else class="pa-8 text-center">
+      <VCard
+        v-else
+        class="pa-8 text-center"
+      >
         <VCardText>
-          <p class="text-h6">No se encontraron motores</p>
+          <p class="text-h6">
+            No se encontraron motores
+          </p>
           <p>Intenta ajustar los filtros de búsqueda.</p>
         </VCardText>
       </VCard>
@@ -209,5 +312,15 @@ const search = () => {
 }
 .price {
   font-size: 24px;
+}
+.top-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.search-btn {
+  height: 56px;
+  width: 56px;
 }
 </style>


### PR DESCRIPTION
## Summary
- make tienda search bar visible and aligned with ordering dropdown
- sort motores list by newest items by default

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule 'valid-appcardcode-*' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e7a45e38832fa4221d50d44c23cd