### PR TITLE
feat: implement advanced tienda filters

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
@@ -11,30 +11,79 @@ interface Term {
 }
 
 // -- State Management --
-const selectedCategory = ref<string | null>(null);
 const selectedBrand = ref<number | null>(null);
-const selectedCountry = ref<string | null>(null);
-const selectedState = ref<string | null>(null);
-const typeModel = ref('');
 const productTypes = ref<string[]>([]);
+const selectedTechnology = ref<string | null>(null);
+const selectedDCSubtype = ref<string | null>(null);
+const selectedACSubtype = ref<string | null>(null);
 const selectedPar = ref<string | null>(null);
 const selectedPotencia = ref<string | null>(null);
 const selectedVelocidad = ref<string | null>(null);
+const searchInput = ref('');
 const searchTerm = ref('');
 const order = ref<string | null>(null);
 
-const parOptions = ['0-50', '50-100'];
+const parOptions = ['0-5', '5-20', '20-50', '>50'];
 const potenciaOptions = ['0-1 kW', '1-5 kW'];
 const velocidadOptions = ['500 rpm', '1500 rpm'];
+const technologyOptions = ['Continua (DC)', 'Alterna (AC)'];
+const dcTypeOptions = ['Imanes Permanentes', 'Excitación Independiente'];
+const acTypeOptions = ['Convencional', 'Brushless', 'Cabezal'];
 const orderOptions = ['Recientes', 'Precio asc', 'Precio desc'];
 
 const itemsPerPage = ref(9);
 const page = ref(1);
 
-// -- Data Fetching --
-const { data: categoriesData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/motor-categories'));
-const categories = computed(() => categoriesData.value || []);
+const sanitize = (str: string) =>
+  str
+    .normalize('NFD').replace(new RegExp('[\\u0300-\\u036f]', 'g'), '')
+    .replace(/[¿?.,!]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
 
+watch(searchInput, val => {
+  const term = sanitize(val);
+  searchTerm.value = term;
+  if (term.includes('motor')) productTypes.value = ['motor'];
+  else if (term.includes('regulador')) productTypes.value = ['regulador'];
+  else if (term) productTypes.value = ['otros-repuestos'];
+  else productTypes.value = [];
+  page.value = 1;
+});
+
+const selectedCategory = computed(() => productTypes.value[0] || null);
+const showTechnology = computed(() => ['motor', 'regulador'].includes(selectedCategory.value || ''));
+const showDcType = computed(() => selectedCategory.value === 'motor' && selectedTechnology.value === 'Continua (DC)');
+const showAcType = computed(() => selectedCategory.value === 'motor' && selectedTechnology.value === 'Alterna (AC)');
+const showParFilter = computed(() => showDcType.value && selectedDCSubtype.value === 'Imanes Permanentes');
+const showDcPotenciaFilter = computed(() => showDcType.value && selectedDCSubtype.value === 'Excitación Independiente');
+const showAcFilters = computed(() => showAcType.value && !!selectedACSubtype.value);
+const showVelocidadFilter = computed(() => showParFilter.value || showDcPotenciaFilter.value || showAcFilters.value);
+const showPotenciaFilter = computed(() => showDcPotenciaFilter.value || showAcFilters.value);
+
+watch(selectedTechnology, () => {
+  selectedDCSubtype.value = null;
+  selectedACSubtype.value = null;
+  selectedPar.value = null;
+  selectedPotencia.value = null;
+  selectedVelocidad.value = null;
+  page.value = 1;
+});
+
+watch(selectedDCSubtype, () => {
+  selectedPar.value = null;
+  selectedPotencia.value = null;
+  selectedVelocidad.value = null;
+  page.value = 1;
+});
+
+watch(selectedACSubtype, () => {
+  selectedPotencia.value = null;
+  selectedVelocidad.value = null;
+  page.value = 1;
+});
+// -- Data Fetching --
 const { data: brandsData } = await useApi<Term[]>(createUrl('/wp-json/motorlan/v1/marcas'));
 const marcas = computed(() => brandsData.value || []);
 
@@ -51,13 +100,12 @@ const motorsApiUrl = computed(() => {
     page: page.value,
     status: 'publish',
     s: searchTerm.value,
-    category: selectedCategory.value,
+    category: productTypes.value.join(','),
     marca: selectedBrand.value,
-    pais: selectedCountry.value,
-    estado_del_articulo: selectedState.value,
     potencia: selectedPotencia.value,
     velocidad: selectedVelocidad.value,
     par_nominal: selectedPar.value,
+    tipo_de_alimentacion: selectedTechnology.value,
     ...(order.value ? sortOptions[order.value] : {}),
   };
 
@@ -83,11 +131,6 @@ onMounted(fetchMotors);
 const motors = computed((): Motor[] => motorsData.value?.data || []);
 const totalMotors = computed(() => motorsData.value?.pagination.total || 0);
 const totalPages = computed(() => motorsData.value?.pagination.totalPages || 1);
-
-const search = () => {
-  page.value = 1;
-  fetchMotors();
-};
 </script>
 
 <template>
@@ -99,33 +142,75 @@ const search = () => {
       </div>
       <VDivider thickness="3" class="mb-4" color="error" />
 
-      <VTextField v-model="typeModel" label="Tipo / modelo" variant="outlined" density="comfortable" class="mb-6" />
+      <VTextField
+        v-model="searchInput"
+        placeholder="Motor, Regulador u otros repuestos"
+        variant="outlined"
+        density="comfortable"
+        class="mb-6"
+      />
 
-      <p class="text-body-2 mb-2">Tipo de producto</p>
-      <VCheckbox v-model="productTypes" label="Motor" value="Motor" density="compact" hide-details />
-      <VCheckbox v-model="productTypes" label="Regulador" value="Regulador" density="compact" hide-details />
-      <VCheckbox v-model="productTypes" label="Otros repuestos" value="Otros repuestos" density="compact" hide-details class="mb-6" />
-
-      <AppSelect v-model="selectedPar" label="PAR (Nm)" :items="parOptions" class="mb-4" clearable />
-      <AppSelect v-model="selectedPotencia" label="Potencia" :items="potenciaOptions" class="mb-4" clearable />
-      <AppSelect v-model="selectedVelocidad" label="Velocidad" :items="velocidadOptions" class="mb-4" clearable />
-      <AppSelect v-model="selectedBrand" label="Marcas" :items="marcas" item-title="name" item-value="id" class="mb-4" clearable />
-      <AppSelect v-model="selectedState" label="Estado" :items="['Nuevo','Usado','Restaurado']" class="mb-4" clearable />
+      <AppSelect
+        v-if="showTechnology"
+        v-model="selectedTechnology"
+        label="Tecnología"
+        :items="technologyOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-if="showDcType"
+        v-model="selectedDCSubtype"
+        label="Tipo C.C."
+        :items="dcTypeOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-if="showParFilter"
+        v-model="selectedPar"
+        label="PAR (Mn)"
+        :items="parOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-if="showPotenciaFilter"
+        v-model="selectedPotencia"
+        label="POTENCIA (Kw)"
+        :items="potenciaOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-if="showVelocidadFilter"
+        v-model="selectedVelocidad"
+        label="VELOCIDAD (Rpm)"
+        :items="velocidadOptions"
+        class="mb-4"
+        clearable
+      />
+      <AppSelect
+        v-if="showAcType"
+        v-model="selectedACSubtype"
+        label="Tipo C.A."
+        :items="acTypeOptions"
+        class="mb-4"
+        clearable
+      />
+      <VAutocomplete
+        v-model="selectedBrand"
+        label="Marca"
+        :items="marcas"
+        item-title="name"
+        item-value="id"
+        class="mb-4"
+        clearable
+      />
     </aside>
 
     <section class="flex-grow-1 ps-6">
-      <div class="d-flex align-center mb-6 gap-4">
-        <VTextField
-          v-model="searchTerm"
-          placeholder="Buscar..."
-          variant="outlined"
-          hide-details
-          class="flex-grow-1"
-          @keydown.enter="search"
-        />
-        <VBtn icon color="error" :loading="loading" @click="search">
-          <VIcon>mdi-magnify</VIcon>
-        </VBtn>
+      <div class="d-flex justify-end mb-6">
         <AppSelect v-model="order" :items="orderOptions" label="Ordenar" clearable style="max-width:220px" />
       </div>
 
@@ -146,8 +231,11 @@ const search = () => {
             <div class="motor-image mb-6">
               <img :src="motor.imagen_destacada?.url || '/placeholder.png'" alt="" />
             </div>
-            <div class="text-error text-body-1 mb-4">
+            <div class="text-error text-body-1 mb-1">
               {{ motor.title }}
+            </div>
+            <div class="text-caption mb-4">
+              {{ motor.acf.estado_del_articulo }}
             </div>
             <div class="d-flex justify-space-between align-center">
               <VBtn

--- a/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php
@@ -399,8 +399,8 @@ function motorlan_get_motors_callback( $request ) {
 
     // Define the list of fields that can be used for filtering.
     $filterable_fields = [
-        'marca', 'tipo_o_referencia', 'potencia', 'velocidad', 'par_nominal', 'voltaje', 'intensidad',
-        'pais', 'provincia', 'estado_del_articulo', 'posibilidad_de_alquiler', 'tipo_de_alimentacion',
+        'marca', 'tipo_o_referencia', 'potencia', 'velocidad', 'par_nominal', 'intensidad',
+        'pais', 'provincia', 'tipo_de_alimentacion',
         'servomotores', 'regulacion_electronica_drivers', 'precio_de_venta', 'precio_negociable', 'uuid'
     ];
 
@@ -410,7 +410,7 @@ function motorlan_get_motors_callback( $request ) {
             $meta_query[] = array(
                 'key'     => $field_name,
                 'value'   => sanitize_text_field($params[$field_name]),
-                'compare' => '=',
+                'compare' => $field_name === 'tipo_o_referencia' ? 'LIKE' : '=',
             );
         }
     }
@@ -426,10 +426,11 @@ function motorlan_get_motors_callback( $request ) {
 
     // Filter by category (categoria taxonomy)
     if ( !empty($params['category']) ) {
+        $terms = array_map( 'sanitize_text_field', explode( ',', $params['category'] ) );
         $tax_query[] = array(
             'taxonomy' => 'categoria',
             'field'    => 'slug',
-            'terms'    => sanitize_text_field($params['category']),
+            'terms'    => $terms,
         );
     }
 


### PR DESCRIPTION
## Summary
- add hierarchical search-driven filters for motors, regulators and spare parts
- support brand autocomplete and display item state in listings
- drop deprecated voltaje, alquiler and estado filters from API

## Testing
- `php -l wp-content/plugins/motorlan-api-vue/includes/api/motor-routes.php`
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/dev.motorlan/package.json')
- `npm run lint` (fails: ENOENT: no such file or directory, open '/workspace/dev.motorlan/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68a8e8464074832f95614226f3dae2a3