### PR TITLE
feat(i18n): Add translations for tienda and add motor pages

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/add/index.vue
@@ -3,9 +3,16 @@ import { onMounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useToast } from '@/composables/useToast'
 import { useApi } from '@/composables/useApi'
+import { useI18n } from 'vue-i18n'
+import ar from '../i18n/ar.json'
+import en from '../i18n/en.json'
+import es from '../i18n/es.json'
+import eu from '../i18n/eu.json'
+import fr from '../i18n/fr.json'
 
 const { showToast } = useToast()
 const router = useRouter()
+const { t, mergeLocaleMessage } = useI18n()
 
 // Stepper state
 const currentStep = ref(1)
@@ -60,16 +67,29 @@ const userData = ref<any>(null)
 const marcas = ref([])
 const categories = ref([])
 
-const postTypeOptions = [
-  { title: 'Motor', value: 'motor' },
-  { title: 'Regulador', value: 'regulador' },
-  { title: 'Otro Repuesto', value: 'otro_repuesto' },
-]
+const postTypeOptions = computed(() => [
+  { title: t('add_motor.post_type_options.motor'), value: 'motor' },
+  { title: t('add_motor.post_type_options.regulator'), value: 'regulador' },
+  { title: t('add_motor.post_type_options.other_spare_part'), value: 'otro_repuesto' },
+])
+
+const conditionOptions = computed(() => [
+  { title: t('add_motor.condition_options.new'), value: 'Nuevo' },
+  { title: t('add_motor.condition_options.used'), value: 'Usado' },
+  { title: t('add_motor.condition_options.restored'), value: 'Restaurado' },
+])
+
+const countryOptions = computed(() => [
+  { title: t('add_motor.country_options.spain'), value: 'España' },
+  { title: t('add_motor.country_options.portugal'), value: 'Portugal' },
+  { title: t('add_motor.country_options.france'), value: 'Francia' },
+])
 
 const pageTitle = computed(() => {
-  const selectedType = postTypeOptions.find(o => o.value === postType.value)
+  const selectedType = postTypeOptions.value.find(o => o.value === postType.value)
+  const postTypeTitle = selectedType ? selectedType.title : ''
 
-  return selectedType ? `Añadir Nuevo ${selectedType.title}` : 'Añadir Nuevo'
+  return t('add_motor.title', { postType: postTypeTitle })
 })
 
 const apiEndpoint = computed(() => {
@@ -87,6 +107,11 @@ const apiEndpoint = computed(() => {
 
 // Fetch initial data for selects
 onMounted(async () => {
+  mergeLocaleMessage('ar', ar)
+  mergeLocaleMessage('en', en)
+  mergeLocaleMessage('es', es)
+  mergeLocaleMessage('eu', eu)
+  mergeLocaleMessage('fr', fr)
   try {
     const [
       marcasResponse,
@@ -185,7 +210,7 @@ const createPostAndContinue = async () => {
     })
 
     newPostId.value = response.data.value.id
-    showToast('Publicación creada. Ahora decide sobre la garantía.', 'success')
+    showToast(t('add_motor.toasts.post_created_success'), 'success')
 
     if (postType.value === 'otro_repuesto') {
       router.push('/apps/motors/motor/list')
@@ -195,7 +220,7 @@ const createPostAndContinue = async () => {
     }
   }
   catch (error: any) {
-    showToast(`Error al crear la publicación: ${error.message}`, 'error')
+    showToast(t('add_motor.toasts.post_created_error', { message: error.message }), 'error')
     console.error('Failed to create post:', error)
   }
 }
@@ -203,8 +228,8 @@ const createPostAndContinue = async () => {
 // Step 2: Skip warranty
 const skipGarantia = () => {
   // A simple confirm dialog
-  if (confirm('La publicación se publicará sin la garantía Motorlan. ¿Estás seguro?')) {
-    showToast('Publicación sin garantía.', 'info')
+  if (confirm(t('add_motor.toasts.warranty_skipped_confirmation'))) {
+    showToast(t('add_motor.toasts.warranty_skipped_info'), 'info')
     router.push('/apps/motors/motor/list')
   }
 }
@@ -220,7 +245,7 @@ const goToGarantiaForm = () => {
 // Step 3: Submit warranty
 const submitGarantia = async () => {
   if (!newPostId.value) {
-    showToast('Error: No se ha encontrado el ID de la publicación.', 'error')
+    showToast(t('add_motor.toasts.post_id_not_found_error'), 'error')
 
     return
   }
@@ -232,11 +257,11 @@ const submitGarantia = async () => {
       method: 'POST',
       body: garantiaData.value,
     })
-    showToast('Garantía solicitada con éxito. Publicación realizada.', 'success')
+    showToast(t('add_motor.toasts.warranty_request_success'), 'success')
     router.push('/apps/motors/motor/list')
   }
   catch (error: any) {
-    showToast(`Error al solicitar la garantía: ${error.message}`, 'error')
+    showToast(t('add_motor.toasts.warranty_request_error', { message: error.message }), 'error')
     console.error('Failed to submit garantia:', error)
   }
 }
@@ -252,7 +277,7 @@ const submitGarantia = async () => {
         <span
           v-if="postType !== 'otro_repuesto'"
           class="text-body-1"
-        >Paso {{ currentStep }} de 3</span>
+        >{{ t('add_motor.step', { currentStep }) }}</span>
       </div>
       <div class="d-flex gap-4 align-center flex-wrap">
         <VBtn
@@ -260,13 +285,13 @@ const submitGarantia = async () => {
           color="secondary"
           @click="router.push('/apps/motors/motor/list')"
         >
-          Descartar
+          {{ t('add_motor.buttons.discard') }}
         </VBtn>
         <VBtn
           v-if="currentStep === 1"
           @click="createPostAndContinue"
         >
-          Guardar y Continuar
+          {{ t('add_motor.buttons.save_and_continue') }}
         </VBtn>
       </div>
     </div>
@@ -283,7 +308,7 @@ const submitGarantia = async () => {
               >
                 <AppSelect
                   v-model="postType"
-                  label="Tipo de Publicación"
+                  :label="t('add_motor.post_details.publication_type')"
                   :items="postTypeOptions"
                 />
               </VCol>
@@ -292,7 +317,7 @@ const submitGarantia = async () => {
         </VCard>
         <VCard
           class="mb-6"
-          :title="`Detalles del ${postType}`"
+          :title="t('add_motor.post_details.section_title', { postType })"
         >
           <VCardText>
             <VRow>
@@ -302,8 +327,8 @@ const submitGarantia = async () => {
               >
                 <AppTextField
                   v-model="postData.title"
-                  label="Título de la publicación"
-                  placeholder="Título"
+                  :label="t('add_motor.post_details.title')"
+                  :placeholder="t('add_motor.post_details.title_placeholder')"
                 />
               </VCol>
               <VCol
@@ -312,8 +337,8 @@ const submitGarantia = async () => {
               >
                 <AppTextField
                   v-model="postData.acf.tipo_o_referencia"
-                  label="Tipo o referencia"
-                  placeholder="Referencia"
+                  :label="t('add_motor.post_details.reference')"
+                  :placeholder="t('add_motor.post_details.reference_placeholder')"
                 />
               </VCol>
               <VCol
@@ -322,7 +347,7 @@ const submitGarantia = async () => {
               >
                 <AppSelect
                   v-model="postData.acf.marca"
-                  label="Marca"
+                  :label="t('add_motor.post_details.brand')"
                   :items="marcas"
                 />
               </VCol>
@@ -332,7 +357,7 @@ const submitGarantia = async () => {
               >
                 <AppSelect
                   v-model="postData.categories"
-                  label="Categoría"
+                  :label="t('add_motor.post_details.category')"
                   :items="categories"
                   multiple
                 />
@@ -344,9 +369,9 @@ const submitGarantia = async () => {
                 >
                   <AppTextField
                     v-model="postData.acf.potencia"
-                    label="Potencia (kW)"
+                    :label="t('add_motor.post_details.power')"
                     type="number"
-                    placeholder="100"
+                    :placeholder="t('add_motor.post_details.power_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -355,9 +380,9 @@ const submitGarantia = async () => {
                 >
                   <AppTextField
                     v-model="postData.acf.velocidad"
-                    label="Velocidad (rpm)"
+                    :label="t('add_motor.post_details.speed')"
                     type="number"
-                    placeholder="3000"
+                    :placeholder="t('add_motor.post_details.speed_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -366,9 +391,9 @@ const submitGarantia = async () => {
                 >
                   <AppTextField
                     v-model="postData.acf.par_nominal"
-                    label="PAR Nominal (Nm)"
+                    :label="t('add_motor.post_details.torque')"
                     type="number"
-                    placeholder="50"
+                    :placeholder="t('add_motor.post_details.torque_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -377,9 +402,9 @@ const submitGarantia = async () => {
                 >
                   <AppTextField
                     v-model="postData.acf.voltaje"
-                    label="Voltaje (V)"
+                    :label="t('add_motor.post_details.voltage')"
                     type="number"
-                    placeholder="220"
+                    :placeholder="t('add_motor.post_details.voltage_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -388,9 +413,9 @@ const submitGarantia = async () => {
                 >
                   <AppTextField
                     v-model="postData.acf.intensidad"
-                    label="Intensidad (A)"
+                    :label="t('add_motor.post_details.intensity')"
                     type="number"
-                    placeholder="10"
+                    :placeholder="t('add_motor.post_details.intensity_placeholder')"
                   />
                 </VCol>
               </template>
@@ -400,8 +425,8 @@ const submitGarantia = async () => {
               >
                 <AppSelect
                   v-model="postData.acf.pais"
-                  label="País (localización)"
-                  :items="['España', 'Portugal', 'Francia']"
+                  :label="t('add_motor.post_details.country')"
+                  :items="countryOptions"
                 />
               </VCol>
               <VCol
@@ -410,8 +435,8 @@ const submitGarantia = async () => {
               >
                 <AppTextField
                   v-model="postData.acf.provincia"
-                  label="Provincia"
-                  placeholder="Madrid"
+                  :label="t('add_motor.post_details.province')"
+                  :placeholder="t('add_motor.post_details.province_placeholder')"
                 />
               </VCol>
               <VCol
@@ -420,15 +445,15 @@ const submitGarantia = async () => {
               >
                 <AppSelect
                   v-model="postData.acf.estado_del_articulo"
-                  label="Estado del artículo"
-                  :items="['Nuevo', 'Usado', 'Restaurado']"
+                  :label="t('add_motor.post_details.condition')"
+                  :items="conditionOptions"
                 />
               </VCol>
               <VCol cols="12">
                 <VTextarea
                   v-model="postData.acf.descripcion"
-                  label="Descripción"
-                  placeholder="Descripción del producto"
+                  :label="t('add_motor.post_details.description')"
+                  :placeholder="t('add_motor.post_details.description_placeholder')"
                 />
               </VCol>
               <template v-if="postType === 'motor' || postType === 'regulador'">
@@ -439,14 +464,14 @@ const submitGarantia = async () => {
                   <VRadioGroup
                     v-model="postData.acf.posibilidad_de_alquiler"
                     inline
-                    label="Posibilidad de alquiler"
+                    :label="t('add_motor.post_details.rent_option')"
                   >
                     <VRadio
-                      label="Sí"
+                      :label="t('add_motor.boolean_options.yes')"
                       value="Sí"
                     />
                     <VRadio
-                      label="No"
+                      :label="t('add_motor.boolean_options.no')"
                       value="No"
                     />
                   </VRadioGroup>
@@ -458,14 +483,14 @@ const submitGarantia = async () => {
                   <VRadioGroup
                     v-model="postData.acf.tipo_de_alimentacion"
                     inline
-                    label="Tipo de alimentación"
+                    :label="t('add_motor.post_details.power_supply_type')"
                   >
                     <VRadio
-                      label="Continua (C.C.)"
+                      :label="t('add_motor.power_supply_options.dc')"
                       value="Continua (C.C.)"
                     />
                     <VRadio
-                      label="Alterna (C.A.)"
+                      :label="t('add_motor.power_supply_options.ac')"
                       value="Alterna (C.A.)"
                     />
                   </VRadioGroup>
@@ -476,7 +501,7 @@ const submitGarantia = async () => {
                 >
                   <VCheckbox
                     v-model="postData.acf.servomotores"
-                    label="Servomotores"
+                    :label="t('add_motor.post_details.servomotors')"
                   />
                 </VCol>
                 <VCol
@@ -485,7 +510,7 @@ const submitGarantia = async () => {
                 >
                   <VCheckbox
                     v-model="postData.acf.regulacion_electronica_drivers"
-                    label="Regulación electrónica/Drivers"
+                    :label="t('add_motor.post_details.electronic_regulation')"
                   />
                 </VCol>
               </template>
@@ -495,9 +520,9 @@ const submitGarantia = async () => {
               >
                 <AppTextField
                   v-model="postData.acf.precio_de_venta"
-                  label="Precio de venta (€)"
+                  :label="t('add_motor.post_details.price')"
                   type="number"
-                  placeholder="1000"
+                  :placeholder="t('add_motor.post_details.price_placeholder')"
                 />
               </VCol>
               <VCol
@@ -506,9 +531,9 @@ const submitGarantia = async () => {
               >
                 <AppTextField
                   v-model="postData.acf.stock"
-                  label="Stock"
+                  :label="t('add_motor.post_details.stock')"
                   type="number"
-                  placeholder="1"
+                  :placeholder="t('add_motor.post_details.stock_placeholder')"
                 />
               </VCol>
               <VCol
@@ -518,14 +543,14 @@ const submitGarantia = async () => {
                 <VRadioGroup
                   v-model="postData.acf.precio_negociable"
                   inline
-                  label="Precio negociable"
+                  :label="t('add_motor.post_details.negotiable_price')"
                 >
                   <VRadio
-                    label="Sí"
+                    :label="t('add_motor.boolean_options.yes')"
                     value="Sí"
                   />
                   <VRadio
-                    label="No"
+                    :label="t('add_motor.boolean_options.no')"
                     value="No"
                   />
                 </VRadioGroup>
@@ -534,14 +559,14 @@ const submitGarantia = async () => {
                 <VRadioGroup
                   v-model="postData.status"
                   inline
-                  label="Publicar (ACF)"
+                  :label="t('add_motor.post_details.publish_acf')"
                 >
                   <VRadio
-                    label="Publicar"
+                    :label="t('add_motor.post_details.publish_status_publish')"
                     value="publish"
                   />
                   <VRadio
-                    label="Borrador"
+                    :label="t('add_motor.post_details.publish_status_draft')"
                     value="draft"
                   />
                 </VRadioGroup>
@@ -551,7 +576,7 @@ const submitGarantia = async () => {
         </VCard>
         <VCard
           class="mb-6"
-          title="Imagen Principal"
+          :title="t('add_motor.media.main_image')"
         >
           <VCardText>
             <DropZone @file-added="handleFeaturedImageUpload" />
@@ -559,7 +584,7 @@ const submitGarantia = async () => {
         </VCard>
         <VCard
           class="mb-6"
-          title="Galería de Imágenes"
+          :title="t('add_motor.media.image_gallery')"
         >
           <VCardText>
             <DropZone @file-added="handleGalleryImageUpload" />
@@ -567,7 +592,7 @@ const submitGarantia = async () => {
         </VCard>
         <VCard
           class="mb-6"
-          title="Documentación Adicional"
+          :title="t('add_motor.media.additional_documentation')"
         >
           <VCardText>
             <div
@@ -577,12 +602,12 @@ const submitGarantia = async () => {
             >
               <AppTextField
                 v-model="doc.nombre"
-                label="Nombre del Documento"
-                placeholder="Manual de usuario"
+                :label="t('add_motor.media.document_name')"
+                :placeholder="t('add_motor.media.document_name_placeholder')"
                 style="width: 300px;"
               />
               <VFileInput
-                label="Subir Archivo"
+                :label="t('add_motor.media.upload_file')"
                 @change="event => handleFileUpload(event, index)"
               />
             </div>
@@ -590,7 +615,7 @@ const submitGarantia = async () => {
               v-if="postData.acf.documentacion_adicional.length < 5"
               @click="addDocument"
             >
-              Añadir Documento
+              {{ t('add_motor.buttons.add_document') }}
             </VBtn>
           </VCardText>
         </VCard>
@@ -600,19 +625,19 @@ const submitGarantia = async () => {
     <!-- Step 2: Warranty Offer -->
     <VCard
       v-if="currentStep === 2"
-      title="Añadir Garantía Motorlan"
+      :title="t('add_motor.warranty.add_warranty_title')"
       class="mb-6"
     >
       <VCardText>
         <p class="mb-4">
-          <strong>¡Solicita la Garantía Motorlan, tu producto se venderá mejor!</strong>
+          <strong>{{ t('add_motor.warranty.add_warranty_subtitle') }}</strong>
         </p>
         <p>
-          Envía el producto a Motorlan para su revisión y puesta a punto. El envío corre a cargo del solicitante.
-          Una vez inspeccionado, te enviaremos un presupuesto para su puesta a punto con garantía.
+          {{ t('add_motor.warranty.add_warranty_text1') }}
+          {{ t('add_motor.warranty.add_warranty_text2') }}
         </p>
         <p class="mt-2">
-          La garantía de los trabajos y materiales es de 6 meses.
+          {{ t('add_motor.warranty.add_warranty_text3') }}
         </p>
       </VCardText>
       <VCardActions>
@@ -621,10 +646,10 @@ const submitGarantia = async () => {
           color="secondary"
           @click="skipGarantia"
         >
-          Omitir
+          {{ t('add_motor.buttons.skip') }}
         </VBtn>
         <VBtn @click="goToGarantiaForm">
-          Aceptar y Añadir Garantía
+          {{ t('add_motor.buttons.accept_and_add_warranty') }}
         </VBtn>
       </VCardActions>
     </VCard>
@@ -632,7 +657,7 @@ const submitGarantia = async () => {
     <!-- Step 3: Warranty Form -->
     <VCard
       v-if="currentStep === 3"
-      title="Formulario de Garantía"
+      :title="t('add_motor.warranty.form_title')"
       class="mb-6"
     >
       <VCardText>
@@ -641,14 +666,14 @@ const submitGarantia = async () => {
             <VRadioGroup
               v-model="garantiaData.is_same_address"
               inline
-              label="¿El producto se encuentra en la misma dirección de tu empresa?"
+              :label="t('add_motor.warranty.same_address_question')"
             >
               <VRadio
-                label="Sí"
+                :label="t('add_motor.boolean_options.yes')"
                 value="SÍ"
               />
               <VRadio
-                label="No"
+                :label="t('add_motor.boolean_options.no')"
                 value="NO"
               />
             </VRadioGroup>
@@ -660,8 +685,8 @@ const submitGarantia = async () => {
             >
               <AppTextField
                 v-model="garantiaData.direccion_motor"
-                label="Dirección de recogida del producto"
-                placeholder="Calle, número, piso"
+                :label="t('add_motor.warranty.pickup_address')"
+                :placeholder="t('add_motor.warranty.pickup_address_placeholder')"
               />
             </VCol>
             <VCol
@@ -670,43 +695,43 @@ const submitGarantia = async () => {
             >
               <AppTextField
                 v-model="garantiaData.cp_motor"
-                label="Código Postal"
-                placeholder="28001"
+                :label="t('add_motor.warranty.postal_code')"
+                :placeholder="t('add_motor.warranty.postal_code_placeholder')"
               />
             </VCol>
           </template>
           <VCol cols="12">
             <p class="text-body-1 font-weight-medium">
-              ENVÍO
+              {{ t('add_motor.warranty.shipping_title') }}
             </p>
             <p class="text-caption">
-              En los casos de envío de material todo transporte se realiza a portes pagados por el cliente mediante el transportista que nos indique.
+              {{ t('add_motor.warranty.shipping_text') }}
             </p>
             <AppTextField
               v-model="garantiaData.agencia_transporte"
-              label="Agencia de transporte *"
-              placeholder="Indique su agencia"
+              :label="t('add_motor.warranty.shipping_agency')"
+              :placeholder="t('add_motor.warranty.shipping_agency_placeholder')"
               class="mt-4"
             />
           </VCol>
 
           <VCol cols="12">
             <p class="text-body-1 font-weight-medium">
-              FORMA DE PAGO
+              {{ t('add_motor.warranty.payment_method_title') }}
             </p>
             <p class="text-caption">
-              La forma de pago en las reparaciones se realiza al contado mediante una de estas dos modalidades.
+              {{ t('add_motor.warranty.payment_method_text') }}
             </p>
             <VRadioGroup
               v-model="garantiaData.modalidad_pago"
               class="mt-4"
             >
               <VRadio
-                label="Contra reembolso"
+                :label="t('add_motor.warranty.payment_method_cod')"
                 value="Contra reembolso"
               />
               <VRadio
-                label="Transferencia a nuestra cuenta previa a la entrega"
+                :label="t('add_motor.warranty.payment_method_transfer')"
                 value="Transferencia"
               />
             </VRadioGroup>
@@ -715,8 +740,8 @@ const submitGarantia = async () => {
           <VCol cols="12">
             <VTextarea
               v-model="garantiaData.comentarios"
-              label="Comentarios"
-              placeholder="Cualquier información adicional"
+              :label="t('add_motor.warranty.comments')"
+              :placeholder="t('add_motor.warranty.comments_placeholder')"
             />
           </VCol>
         </VRow>
@@ -727,10 +752,10 @@ const submitGarantia = async () => {
           variant="tonal"
           @click="currentStep = 2"
         >
-          Volver
+          {{ t('add_motor.buttons.go_back') }}
         </VBtn>
         <VBtn @click="submitGarantia">
-          Solicitar Garantía
+          {{ t('add_motor.buttons.request_warranty') }}
         </VBtn>
       </VCardActions>
     </VCard>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/ar.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/ar.json
@@ -1,0 +1,116 @@
+{
+  "add_motor": {
+    "title": "إضافة جديد {postType}",
+    "step": "خطوة {currentStep} من 3",
+    "buttons": {
+      "discard": "تجاهل",
+      "save_and_continue": "حفظ ومتابعة",
+      "add_document": "إضافة مستند",
+      "skip": "تخطي",
+      "accept_and_add_warranty": "قبول وإضافة ضمان",
+      "go_back": "رجوع",
+      "request_warranty": "طلب ضمان"
+    },
+    "post_details": {
+      "section_title": "تفاصيل {postType}",
+      "publication_type": "نوع المنشور",
+      "title": "عنوان المنشور",
+      "title_placeholder": "العنوان",
+      "reference": "النوع أو المرجع",
+      "reference_placeholder": "المرجع",
+      "brand": "العلامة التجارية",
+      "category": "الفئة",
+      "power": "القدرة (كيلوواط)",
+      "power_placeholder": "100",
+      "speed": "السرعة (دورة في الدقيقة)",
+      "speed_placeholder": "3000",
+      "torque": "عزم الدوران الاسمي (نيوتن متر)",
+      "torque_placeholder": "50",
+      "voltage": "الجهد (فولت)",
+      "voltage_placeholder": "220",
+      "intensity": "الشدة (أمبير)",
+      "intensity_placeholder": "10",
+      "country": "البلد (الموقع)",
+      "province": "المقاطعة",
+      "province_placeholder": "مدريد",
+      "condition": "حالة السلعة",
+      "description": "الوصف",
+      "description_placeholder": "وصف المنتج",
+      "rent_option": "إمكانية الإيجار",
+      "power_supply_type": "نوع مصدر الطاقة",
+      "servomotors": "محركات سيرفو",
+      "electronic_regulation": "تنظيم إلكتروني/برامج تشغيل",
+      "price": "سعر البيع (€)",
+      "price_placeholder": "1000",
+      "stock": "المخزون",
+      "stock_placeholder": "1",
+      "negotiable_price": "السعر قابل للتفاوض",
+      "publish_acf": "نشر (ACF)",
+      "publish_status_publish": "نشر",
+      "publish_status_draft": "مسودة"
+    },
+    "post_type_options": {
+        "motor": "محرك",
+        "regulator": "منظم",
+        "other_spare_part": "قطعة غيار أخرى"
+    },
+    "condition_options": {
+        "new": "جديد",
+        "used": "مستعمل",
+        "restored": "مجدد"
+    },
+    "country_options": {
+        "spain": "إسبانيا",
+        "portugal": "البرتغال",
+        "france": "فرنسا"
+    },
+    "boolean_options": {
+        "yes": "نعم",
+        "no": "لا"
+    },
+    "power_supply_options": {
+        "dc": "تيار مباشر (C.C.)",
+        "ac": "تيار متردد (C.A.)"
+    },
+    "media": {
+      "main_image": "الصورة الرئيسية",
+      "image_gallery": "معرض الصور",
+      "additional_documentation": "وثائق إضافية",
+      "document_name": "اسم المستند",
+      "document_name_placeholder": "دليل المستخدم",
+      "upload_file": "تحميل ملف"
+    },
+    "warranty": {
+      "add_warranty_title": "إضافة ضمان موتورلان",
+      "add_warranty_subtitle": "اطلب ضمان موتورلان، سيباع منتجك بشكل أفضل!",
+      "add_warranty_text1": "أرسل المنتج إلى موتورلان للمراجعة والضبط. يتحمل مقدم الطلب تكلفة الشحن.",
+      "add_warranty_text2": "بمجرد فحصه، سنرسل لك عرض أسعار لضبطه مع الضمان.",
+      "add_warranty_text3": "ضمان العمل والمواد هو 6 أشهر.",
+      "form_title": "نموذج الضمان",
+      "same_address_question": "هل المنتج موجود في نفس عنوان شركتك؟",
+      "pickup_address": "عنوان استلام المنتج",
+      "pickup_address_placeholder": "الشارع، الرقم، الطابق",
+      "postal_code": "الرمز البريدي",
+      "postal_code_placeholder": "28001",
+      "shipping_title": "الشحن",
+      "shipping_text": "في حالات شحن المواد، يتم دفع جميع تكاليف النقل من قبل العميل من خلال شركة النقل التي يشيرون إليها.",
+      "shipping_agency": "وكالة النقل *",
+      "shipping_agency_placeholder": "اذكر وكالتك",
+      "payment_method_title": "طريقة الدفع",
+      "payment_method_text": "يتم الدفع للإصلاحات نقدًا من خلال إحدى هاتين الطريقتين.",
+      "payment_method_cod": "الدفع عند الاستلام",
+      "payment_method_transfer": "التحويل إلى حسابنا قبل التسليم",
+      "comments": "تعليقات",
+      "comments_placeholder": "أي معلومات إضافية"
+    },
+    "toasts": {
+      "post_created_success": "تم إنشاء المنشور. قرر الآن بشأن الضمان.",
+      "post_created_error": "خطأ في إنشاء المنشور: {message}",
+      "warranty_skipped_confirmation": "سيتم نشر المنشور بدون ضمان موتورلان. هل أنت متأكد؟",
+      "warranty_skipped_info": "منشور بدون ضمان.",
+      "post_id_not_found_error": "خطأ: لم يتم العثور على معرف المنشور.",
+      "warranty_request_success": "تم طلب الضمان بنجاح. تم النشر.",
+      "warranty_request_error": "خطأ في طلب الضمان: {message}"
+    }
+  }
+}

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/en.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/en.json
@@ -1,0 +1,116 @@
+{
+  "add_motor": {
+    "title": "Add New {postType}",
+    "step": "Step {currentStep} of 3",
+    "buttons": {
+      "discard": "Discard",
+      "save_and_continue": "Save and Continue",
+      "add_document": "Add Document",
+      "skip": "Skip",
+      "accept_and_add_warranty": "Accept and Add Warranty",
+      "go_back": "Go Back",
+      "request_warranty": "Request Warranty"
+    },
+    "post_details": {
+      "section_title": "{postType} Details",
+      "publication_type": "Publication Type",
+      "title": "Publication Title",
+      "title_placeholder": "Title",
+      "reference": "Type or Reference",
+      "reference_placeholder": "Reference",
+      "brand": "Brand",
+      "category": "Category",
+      "power": "Power (kW)",
+      "power_placeholder": "100",
+      "speed": "Speed (rpm)",
+      "speed_placeholder": "3000",
+      "torque": "Nominal Torque (Nm)",
+      "torque_placeholder": "50",
+      "voltage": "Voltage (V)",
+      "voltage_placeholder": "220",
+      "intensity": "Intensity (A)",
+      "intensity_placeholder": "10",
+      "country": "Country (location)",
+      "province": "Province",
+      "province_placeholder": "Madrid",
+      "condition": "Item Condition",
+      "description": "Description",
+      "description_placeholder": "Product description",
+      "rent_option": "Rental Option",
+      "power_supply_type": "Power Supply Type",
+      "servomotors": "Servomotors",
+      "electronic_regulation": "Electronic Regulation/Drivers",
+      "price": "Selling Price (€)",
+      "price_placeholder": "1000",
+      "stock": "Stock",
+      "stock_placeholder": "1",
+      "negotiable_price": "Negotiable Price",
+      "publish_acf": "Publish (ACF)",
+      "publish_status_publish": "Publish",
+      "publish_status_draft": "Draft"
+    },
+    "post_type_options": {
+        "motor": "Motor",
+        "regulator": "Regulator",
+        "other_spare_part": "Other Spare Part"
+    },
+    "condition_options": {
+        "new": "New",
+        "used": "Used",
+        "restored": "Restored"
+    },
+    "country_options": {
+        "spain": "Spain",
+        "portugal": "Portugal",
+        "france": "France"
+    },
+    "boolean_options": {
+        "yes": "Yes",
+        "no": "No"
+    },
+    "power_supply_options": {
+        "dc": "Direct Current (D.C.)",
+        "ac": "Alternating Current (A.C.)"
+    },
+    "media": {
+      "main_image": "Main Image",
+      "image_gallery": "Image Gallery",
+      "additional_documentation": "Additional Documentation",
+      "document_name": "Document Name",
+      "document_name_placeholder": "User manual",
+      "upload_file": "Upload File"
+    },
+    "warranty": {
+      "add_warranty_title": "Add Motorlan Warranty",
+      "add_warranty_subtitle": "Request the Motorlan Warranty, your product will sell better!",
+      "add_warranty_text1": "Send the product to Motorlan for review and tune-up. The shipment is paid by the applicant.",
+      "add_warranty_text2": "Once inspected, we will send you a quote for its tune-up with warranty.",
+      "add_warranty_text3": "The warranty for work and materials is 6 months.",
+      "form_title": "Warranty Form",
+      "same_address_question": "Is the product at the same address as your company?",
+      "pickup_address": "Product pickup address",
+      "pickup_address_placeholder": "Street, number, floor",
+      "postal_code": "Postal Code",
+      "postal_code_placeholder": "28001",
+      "shipping_title": "SHIPPING",
+      "shipping_text": "In cases of material shipment, all transport is paid by the customer through the carrier they indicate.",
+      "shipping_agency": "Transport agency *",
+      "shipping_agency_placeholder": "Indicate your agency",
+      "payment_method_title": "PAYMENT METHOD",
+      "payment_method_text": "Payment for repairs is made in cash through one of these two methods.",
+      "payment_method_cod": "Cash on delivery",
+      "payment_method_transfer": "Transfer to our account before delivery",
+      "comments": "Comments",
+      "comments_placeholder": "Any additional information"
+    },
+    "toasts": {
+      "post_created_success": "Publication created. Now decide on the warranty.",
+      "post_created_error": "Error creating publication: {message}",
+      "warranty_skipped_confirmation": "The publication will be published without the Motorlan warranty. Are you sure?",
+      "warranty_skipped_info": "Publication without warranty.",
+      "post_id_not_found_error": "Error: Publication ID not found.",
+      "warranty_request_success": "Warranty requested successfully. Publication made.",
+      "warranty_request_error": "Error requesting warranty: {message}"
+    }
+  }
+}

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/es.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/es.json
@@ -1,0 +1,116 @@
+{
+  "add_motor": {
+    "title": "Añadir Nuevo {postType}",
+    "step": "Paso {currentStep} de 3",
+    "buttons": {
+      "discard": "Descartar",
+      "save_and_continue": "Guardar y Continuar",
+      "add_document": "Añadir Documento",
+      "skip": "Omitir",
+      "accept_and_add_warranty": "Aceptar y Añadir Garantía",
+      "go_back": "Volver",
+      "request_warranty": "Solicitar Garantía"
+    },
+    "post_details": {
+      "section_title": "Detalles del {postType}",
+      "publication_type": "Tipo de Publicación",
+      "title": "Título de la publicación",
+      "title_placeholder": "Título",
+      "reference": "Tipo o referencia",
+      "reference_placeholder": "Referencia",
+      "brand": "Marca",
+      "category": "Categoría",
+      "power": "Potencia (kW)",
+      "power_placeholder": "100",
+      "speed": "Velocidad (rpm)",
+      "speed_placeholder": "3000",
+      "torque": "PAR Nominal (Nm)",
+      "torque_placeholder": "50",
+      "voltage": "Voltaje (V)",
+      "voltage_placeholder": "220",
+      "intensity": "Intensidad (A)",
+      "intensity_placeholder": "10",
+      "country": "País (localización)",
+      "province": "Provincia",
+      "province_placeholder": "Madrid",
+      "condition": "Estado del artículo",
+      "description": "Descripción",
+      "description_placeholder": "Descripción del producto",
+      "rent_option": "Posibilidad de alquiler",
+      "power_supply_type": "Tipo de alimentación",
+      "servomotors": "Servomotores",
+      "electronic_regulation": "Regulación electrónica/Drivers",
+      "price": "Precio de venta (€)",
+      "price_placeholder": "1000",
+      "stock": "Stock",
+      "stock_placeholder": "1",
+      "negotiable_price": "Precio negociable",
+      "publish_acf": "Publicar (ACF)",
+      "publish_status_publish": "Publicar",
+      "publish_status_draft": "Borrador"
+    },
+    "post_type_options": {
+        "motor": "Motor",
+        "regulator": "Regulador",
+        "other_spare_part": "Otro Repuesto"
+    },
+    "condition_options": {
+        "new": "Nuevo",
+        "used": "Usado",
+        "restored": "Restaurado"
+    },
+    "country_options": {
+        "spain": "España",
+        "portugal": "Portugal",
+        "france": "Francia"
+    },
+    "boolean_options": {
+        "yes": "Sí",
+        "no": "No"
+    },
+    "power_supply_options": {
+        "dc": "Continua (C.C.)",
+        "ac": "Alterna (C.A.)"
+    },
+    "media": {
+      "main_image": "Imagen Principal",
+      "image_gallery": "Galería de Imágenes",
+      "additional_documentation": "Documentación Adicional",
+      "document_name": "Nombre del Documento",
+      "document_name_placeholder": "Manual de usuario",
+      "upload_file": "Subir Archivo"
+    },
+    "warranty": {
+      "add_warranty_title": "Añadir Garantía Motorlan",
+      "add_warranty_subtitle": "¡Solicita la Garantía Motorlan, tu producto se venderá mejor!",
+      "add_warranty_text1": "Envía el producto a Motorlan para su revisión y puesta a punto. El envío corre a cargo del solicitante.",
+      "add_warranty_text2": "Una vez inspeccionado, te enviaremos un presupuesto para su puesta a punto con garantía.",
+      "add_warranty_text3": "La garantía de los trabajos y materiales es de 6 meses.",
+      "form_title": "Formulario de Garantía",
+      "same_address_question": "¿El producto se encuentra en la misma dirección de tu empresa?",
+      "pickup_address": "Dirección de recogida del producto",
+      "pickup_address_placeholder": "Calle, número, piso",
+      "postal_code": "Código Postal",
+      "postal_code_placeholder": "28001",
+      "shipping_title": "ENVÍO",
+      "shipping_text": "En los casos de envío de material todo transporte se realiza a portes pagados por el cliente mediante el transportista que nos indique.",
+      "shipping_agency": "Agencia de transporte *",
+      "shipping_agency_placeholder": "Indique su agencia",
+      "payment_method_title": "FORMA DE PAGO",
+      "payment_method_text": "La forma de pago en las reparaciones se realiza al contado mediante una de estas dos modalidades.",
+      "payment_method_cod": "Contra reembolso",
+      "payment_method_transfer": "Transferencia a nuestra cuenta previa a la entrega",
+      "comments": "Comentarios",
+      "comments_placeholder": "Cualquier información adicional"
+    },
+    "toasts": {
+      "post_created_success": "Publicación creada. Ahora decide sobre la garantía.",
+      "post_created_error": "Error al crear la publicación: {message}",
+      "warranty_skipped_confirmation": "La publicación se publicará sin la garantía Motorlan. ¿Estás seguro?",
+      "warranty_skipped_info": "Publicación sin garantía.",
+      "post_id_not_found_error": "Error: No se ha encontrado el ID de la publicación.",
+      "warranty_request_success": "Garantía solicitada con éxito. Publicación realizada.",
+      "warranty_request_error": "Error al solicitar la garantía: {message}"
+    }
+  }
+}

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/eu.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/eu.json
@@ -1,0 +1,116 @@
+{
+  "add_motor": {
+    "title": "Gehitu {postType} Berria",
+    "step": "{currentStep}. pausoa 3tik",
+    "buttons": {
+      "discard": "Baztertu",
+      "save_and_continue": "Gorde eta Jarraitu",
+      "add_document": "Dokumentua Gehitu",
+      "skip": "Saltatu",
+      "accept_and_add_warranty": "Onartu eta Bermea Gehitu",
+      "go_back": "Atzera",
+      "request_warranty": "Bermea Eskatu"
+    },
+    "post_details": {
+      "section_title": "{postType}-aren Xehetasunak",
+      "publication_type": "Argitalpen Mota",
+      "title": "Argitalpenaren Izenburua",
+      "title_placeholder": "Izenburua",
+      "reference": "Mota edo Erreferentzia",
+      "reference_placeholder": "Erreferentzia",
+      "brand": "Marka",
+      "category": "Kategoria",
+      "power": "Potentzia (kW)",
+      "power_placeholder": "100",
+      "speed": "Abiadura (rpm)",
+      "speed_placeholder": "3000",
+      "torque": "Pare Nominala (Nm)",
+      "torque_placeholder": "50",
+      "voltage": "Tentsioa (V)",
+      "voltage_placeholder": "220",
+      "intensity": "Intentsitatea (A)",
+      "intensity_placeholder": "10",
+      "country": "Herrialdea (kokapena)",
+      "province": "Probintzia",
+      "province_placeholder": "Madril",
+      "condition": "Artikuluaren Egoera",
+      "description": "Deskribapena",
+      "description_placeholder": "Produktuaren deskribapena",
+      "rent_option": "Alokatzeko Aukera",
+      "power_supply_type": "Elikatze Mota",
+      "servomotors": "Serbomotorrak",
+      "electronic_regulation": "Erregulazio Elektronikoa/Driverrak",
+      "price": "Salmenta Prezioa (€)",
+      "price_placeholder": "1000",
+      "stock": "Stocka",
+      "stock_placeholder": "1",
+      "negotiable_price": "Prezio Negoziagarria",
+      "publish_acf": "Argitaratu (ACF)",
+      "publish_status_publish": "Argitaratu",
+      "publish_status_draft": "Zirriborroa"
+    },
+    "post_type_options": {
+        "motor": "Motorra",
+        "regulator": "Erregulatzailea",
+        "other_spare_part": "Beste Ordezko Pieza"
+    },
+    "condition_options": {
+        "new": "Berria",
+        "used": "Erabilia",
+        "restored": "Berrezarria"
+    },
+    "country_options": {
+        "spain": "Espainia",
+        "portugal": "Portugal",
+        "france": "Frantzia"
+    },
+    "boolean_options": {
+        "yes": "Bai",
+        "no": "Ez"
+    },
+    "power_supply_options": {
+        "dc": "Korronte Zuzena (C.C.)",
+        "ac": "Korronte Alternoa (C.A.)"
+    },
+    "media": {
+      "main_image": "Irudi Nagusia",
+      "image_gallery": "Irudi Galeria",
+      "additional_documentation": "Dokumentazio Gehigarria",
+      "document_name": "Dokumentuaren Izena",
+      "document_name_placeholder": "Erabiltzailearen eskuliburua",
+      "upload_file": "Fitxategia Igo"
+    },
+    "warranty": {
+      "add_warranty_title": "Gehitu Motorlan Bermea",
+      "add_warranty_subtitle": "Eskatu Motorlan Bermea, zure produktua hobeto salduko da!",
+      "add_warranty_text1": "Bidali produktua Motorlan-era berrikusteko eta doitzeko. Bidalketa eskatzailearen kontura doa.",
+      "add_warranty_text2": "Behin ikuskatuta, aurrekontua bidaliko dizugu bermearekin doitzeko.",
+      "add_warranty_text3": "Lanen eta materialen bermea 6 hilabetekoa da.",
+      "form_title": "Bermearen Inprimakia",
+      "same_address_question": "Produktua zure enpresaren helbide berean dago?",
+      "pickup_address": "Produktuaren jasotze helbidea",
+      "pickup_address_placeholder": "Kalea, zenbakia, solairua",
+      "postal_code": "Posta Kodea",
+      "postal_code_placeholder": "28001",
+      "shipping_title": "BIDALKETA",
+      "shipping_text": "Materiala bidaltzeko kasuetan, garraio guztia bezeroak ordainduta egiten da, adierazten digun garraiolariaren bidez.",
+      "shipping_agency": "Garraio agentzia *",
+      "shipping_agency_placeholder": "Adierazi zure agentzia",
+      "payment_method_title": "ORDAINKETA MODUA",
+      "payment_method_text": "Konponketen ordainketa eskudirutan egiten da bi modalitate hauetako baten bidez.",
+      "payment_method_cod": "Ordainketa contra erreembolso",
+      "payment_method_transfer": "Transferentzia gure kontura entregatu aurretik",
+      "comments": "Iruzkinak",
+      "comments_placeholder": "Edozein informazio gehigarri"
+    },
+    "toasts": {
+      "post_created_success": "Argitalpena sortu da. Orain erabaki bermeari buruz.",
+      "post_created_error": "Errorea argitalpena sortzean: {message}",
+      "warranty_skipped_confirmation": "Argitalpena Motorlan bermerik gabe argitaratuko da. Ziur zaude?",
+      "warranty_skipped_info": "Argitalpena bermerik gabe.",
+      "post_id_not_found_error": "Errorea: Ez da argitalpenaren IDa aurkitu.",
+      "warranty_request_success": "Bermea ondo eskatu da. Argitalpena eginda.",
+      "warranty_request_error": "Errorea bermea eskatzean: {message}"
+    }
+  }
+}

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/fr.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/motors/motor/i18n/fr.json
@@ -1,0 +1,116 @@
+{
+  "add_motor": {
+    "title": "Ajouter Nouveau {postType}",
+    "step": "Étape {currentStep} de 3",
+    "buttons": {
+      "discard": "Annuler",
+      "save_and_continue": "Enregistrer et Continuer",
+      "add_document": "Ajouter un Document",
+      "skip": "Ignorer",
+      "accept_and_add_warranty": "Accepter et Ajouter la Garantie",
+      "go_back": "Retour",
+      "request_warranty": "Demander la Garantie"
+    },
+    "post_details": {
+      "section_title": "Détails du {postType}",
+      "publication_type": "Type de Publication",
+      "title": "Titre de la publication",
+      "title_placeholder": "Titre",
+      "reference": "Type ou référence",
+      "reference_placeholder": "Référence",
+      "brand": "Marque",
+      "category": "Catégorie",
+      "power": "Puissance (kW)",
+      "power_placeholder": "100",
+      "speed": "Vitesse (tr/min)",
+      "speed_placeholder": "3000",
+      "torque": "Couple Nominal (Nm)",
+      "torque_placeholder": "50",
+      "voltage": "Tension (V)",
+      "voltage_placeholder": "220",
+      "intensity": "Intensité (A)",
+      "intensity_placeholder": "10",
+      "country": "Pays (localisation)",
+      "province": "Province",
+      "province_placeholder": "Madrid",
+      "condition": "État de l'article",
+      "description": "Description",
+      "description_placeholder": "Description du produit",
+      "rent_option": "Possibilité de location",
+      "power_supply_type": "Type d'alimentation",
+      "servomotors": "Servomoteurs",
+      "electronic_regulation": "Régulation électronique/Drivers",
+      "price": "Prix de vente (€)",
+      "price_placeholder": "1000",
+      "stock": "Stock",
+      "stock_placeholder": "1",
+      "negotiable_price": "Prix négociable",
+      "publish_acf": "Publier (ACF)",
+      "publish_status_publish": "Publier",
+      "publish_status_draft": "Brouillon"
+    },
+    "post_type_options": {
+        "motor": "Moteur",
+        "regulator": "Régulateur",
+        "other_spare_part": "Autre Pièce de Rechange"
+    },
+    "condition_options": {
+        "new": "Neuf",
+        "used": "Occasion",
+        "restored": "Restauré"
+    },
+    "country_options": {
+        "spain": "Espagne",
+        "portugal": "Portugal",
+        "france": "France"
+    },
+    "boolean_options": {
+        "yes": "Oui",
+        "no": "Non"
+    },
+    "power_supply_options": {
+        "dc": "Courant Continu (C.C.)",
+        "ac": "Courant Alternatif (C.A.)"
+    },
+    "media": {
+      "main_image": "Image Principale",
+      "image_gallery": "Galerie d'Images",
+      "additional_documentation": "Documentation Additionnelle",
+      "document_name": "Nom du Document",
+      "document_name_placeholder": "Manuel de l'utilisateur",
+      "upload_file": "Télécharger un Fichier"
+    },
+    "warranty": {
+      "add_warranty_title": "Ajouter la Garantie Motorlan",
+      "add_warranty_subtitle": "Demandez la Garantie Motorlan, votre produit se vendra mieux !",
+      "add_warranty_text1": "Envoyez le produit à Motorlan pour révision et mise au point. L'envoi est à la charge du demandeur.",
+      "add_warranty_text2": "Une fois inspecté, nous vous enverrons un devis pour sa mise au point avec garantie.",
+      "add_warranty_text3": "La garantie des travaux et des matériaux est de 6 mois.",
+      "form_title": "Formulaire de Garantie",
+      "same_address_question": "Le produit se trouve-t-il à la même adresse que votre entreprise ?",
+      "pickup_address": "Adresse de collecte du produit",
+      "pickup_address_placeholder": "Rue, numéro, étage",
+      "postal_code": "Code Postal",
+      "postal_code_placeholder": "28001",
+      "shipping_title": "EXPÉDITION",
+      "shipping_text": "En cas d'envoi de matériel, tout le transport est payé par le client par l'intermédiaire du transporteur qu'il nous indique.",
+      "shipping_agency": "Agence de transport *",
+      "shipping_agency_placeholder": "Indiquez votre agence",
+      "payment_method_title": "MODE DE PAIEMENT",
+      "payment_method_text": "Le paiement des réparations s'effectue au comptant selon l'une de ces deux modalités.",
+      "payment_method_cod": "Contre remboursement",
+      "payment_method_transfer": "Virement sur notre compte avant la livraison",
+      "comments": "Commentaires",
+      "comments_placeholder": "Toute information supplémentaire"
+    },
+    "toasts": {
+      "post_created_success": "Publication créée. Décidez maintenant de la garantie.",
+      "post_created_error": "Erreur lors de la création de la publication : {message}",
+      "warranty_skipped_confirmation": "La publication sera publiée sans la garantie Motorlan. Êtes-vous sûr ?",
+      "warranty_skipped_info": "Publication sans garantie.",
+      "post_id_not_found_error": "Erreur : ID de la publication non trouvé.",
+      "warranty_request_success": "Demande de garantie réussie. Publication effectuée.",
+      "warranty_request_error": "Erreur lors de la demande de garantie : {message}"
+    }
+  }
+}

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
@@ -7,6 +7,9 @@ import TiendaFilters from './components/TiendaFilters.vue'
 import SearchBar from './components/SearchBar.vue'
 import MotorItems from './components/MotorItems.vue'
 import PaginationControls from './components/PaginationControls.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 interface Term {
   id: number
@@ -26,11 +29,11 @@ const selectedVelocidad = ref<string | null>(null);
 const searchTerm = ref('');
 const order = ref<string | null>(null);
 
-const parOptions = ['0-50', '50-100'];
-const potenciaOptions = ['0-1 kW', '1-5 kW'];
-const velocidadOptions = ['500 rpm', '1500 rpm'];
-const technologyOptions = ['Continua (C.C.)', 'Alterna (C.A.)'];
-const orderOptions = ['Recientes', 'Precio asc', 'Precio desc'];
+const parOptions = computed(() => [t('tienda.par_options.range1'), t('tienda.par_options.range2')])
+const potenciaOptions = computed(() => [t('tienda.potencia_options.range1'), t('tienda.potencia_options.range2')])
+const velocidadOptions = computed(() => [t('tienda.velocidad_options.range1'), t('tienda.velocidad_options.range2')])
+const technologyOptions = computed(() => [t('tienda.technology_options.dc'), t('tienda.technology_options.ac')])
+const orderOptions = computed(() => [t('tienda.order_options.recents'), t('tienda.order_options.price_asc'), t('tienda.order_options.price_desc')])
 
 const itemsPerPage = ref(9);
 const page = ref(1);
@@ -43,9 +46,9 @@ const motorsApiUrl = computed(() => {
   const baseUrl = '/wp-json/motorlan/v1/motors'
 
   const sortOptions = {
-    'Recientes': { orderby: 'date', order: 'desc' },
-    'Precio asc': { orderby: 'price', order: 'asc' },
-    'Precio desc': { orderby: 'price', order: 'desc' },
+    [t('tienda.order_options.recents')]: { orderby: 'date', order: 'desc' },
+    [t('tienda.order_options.price_asc')]: { orderby: 'price', order: 'asc' },
+    [t('tienda.order_options.price_desc')]: { orderby: 'price', order: 'desc' },
   }
 
   const queryParams = {

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/ar.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/ar.json
@@ -164,6 +164,29 @@
   "25": "25",
   "50": "50",
   "100": "100",
+  "tienda": {
+    "par_options": {
+      "range1": "0-50",
+      "range2": "50-100"
+    },
+    "potencia_options": {
+      "range1": "0-1 كيلو واط",
+      "range2": "1-5 كيلو واط"
+    },
+    "velocidad_options": {
+      "range1": "500 دورة في الدقيقة",
+      "range2": "1500 دورة في الدقيقة"
+    },
+    "technology_options": {
+      "dc": "تيار مباشر (C.C.)",
+      "ac": "تيار متردد (C.A.)"
+    },
+    "order_options": {
+      "recents": "الأحدث",
+      "price_asc": "السعر تصاعدي",
+      "price_desc": "السعر تنازلي"
+    }
+  },
   "$vuetify": {
     "badge": "شارة",
     "noDataText": "لا تتوافر بيانات",

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/en.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/en.json
@@ -167,6 +167,29 @@
   "Preguntas": "Questions",
   "Opiniones": "Reviews",
   "Favoritos": "Favorites",
+  "tienda": {
+    "par_options": {
+      "range1": "0-50",
+      "range2": "50-100"
+    },
+    "potencia_options": {
+      "range1": "0-1 kW",
+      "range2": "1-5 kW"
+    },
+    "velocidad_options": {
+      "range1": "500 rpm",
+      "range2": "1500 rpm"
+    },
+    "technology_options": {
+      "dc": "Direct Current (D.C.)",
+      "ac": "Alternating Current (A.C.)"
+    },
+    "order_options": {
+      "recents": "Recents",
+      "price_asc": "Price asc",
+      "price_desc": "Price desc"
+    }
+  },
   "$vuetify": {
     "badge": "Badge",
     "noDataText": "No data available",

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/es.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/es.json
@@ -168,6 +168,29 @@
   "Preguntas": "Preguntas",
   "Opiniones": "Opiniones",
   "Favoritos": "Favoritos",
+  "tienda": {
+    "par_options": {
+      "range1": "0-50",
+      "range2": "50-100"
+    },
+    "potencia_options": {
+      "range1": "0-1 kW",
+      "range2": "1-5 kW"
+    },
+    "velocidad_options": {
+      "range1": "500 rpm",
+      "range2": "1500 rpm"
+    },
+    "technology_options": {
+      "dc": "Continua (C.C.)",
+      "ac": "Alterna (C.A.)"
+    },
+    "order_options": {
+      "recents": "Recientes",
+      "price_asc": "Precio asc",
+      "price_desc": "Precio desc"
+    }
+  },
   "$vuetify": {
     "badge": "Insignia",
     "noDataText": "No hay datos disponibles",

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/eu.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/eu.json
@@ -168,6 +168,29 @@
   "Preguntas": "Galderak",
   "Opiniones": "Iritziak",
   "Favoritos": "Gogokoak",
+  "tienda": {
+    "par_options": {
+      "range1": "0-50",
+      "range2": "50-100"
+    },
+    "potencia_options": {
+      "range1": "0-1 kW",
+      "range2": "1-5 kW"
+    },
+    "velocidad_options": {
+      "range1": "500 rpm",
+      "range2": "1500 rpm"
+    },
+    "technology_options": {
+      "dc": "Korronte Zuzena (C.C.)",
+      "ac": "Korronte Alternoa (C.A.)"
+    },
+    "order_options": {
+      "recents": "Berrienak",
+      "price_asc": "Prezioa gorantz",
+      "price_desc": "Prezioa beherantz"
+    }
+  },
   "$vuetify": {
     "badge": "Intsignia",
     "noDataText": "Ez dago daturik eskuragarri",

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/fr.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/fr.json
@@ -165,6 +165,29 @@
   "25": "25",
   "50": "50",
   "100": "100",
+  "tienda": {
+    "par_options": {
+      "range1": "0-50",
+      "range2": "50-100"
+    },
+    "potencia_options": {
+      "range1": "0-1 kW",
+      "range2": "1-5 kW"
+    },
+    "velocidad_options": {
+      "range1": "500 tr/min",
+      "range2": "1500 tr/min"
+    },
+    "technology_options": {
+      "dc": "Courant Continu (C.C.)",
+      "ac": "Courant Alternatif (C.A.)"
+    },
+    "order_options": {
+      "recents": "Récents",
+      "price_asc": "Prix asc",
+      "price_desc": "Prix desc"
+    }
+  },
   "$vuetify": {
     "badge": "Badge",
     "loading": "Chargement",


### PR DESCRIPTION
- Add i18n for hardcoded strings in the `tienda/index.vue` component.
- Add i18n for the `apps/motors/motor/add/index.vue` component.
- Create new translation files for the `add` component and merge them at runtime.
- Update existing translation files with new keys for the `tienda` component.