### PR TITLE
Fix search bar layout and default ordering on store page

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/SearchBar.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/SearchBar.vue
@@ -40,7 +40,8 @@ const onSearch = () => emit('search')
 <style scoped>
 .top-bar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  width: 100%;
   gap: 16px;
   margin-bottom: 24px;
 }

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/index.vue
@@ -27,7 +27,7 @@ const selectedPar = ref<string | null>(null);
 const selectedPotencia = ref<string | null>(null);
 const selectedVelocidad = ref<string | null>(null);
 const searchTerm = ref('');
-const order = ref<string | null>(null);
+const order = ref<string | null>(t('tienda.order_options.recents'));
 
 const parOptions = computed(() => [t('tienda.par_options.range1'), t('tienda.par_options.range2')])
 const potenciaOptions = computed(() => [t('tienda.potencia_options.range1'), t('tienda.potencia_options.range2')])


### PR DESCRIPTION
## Summary
- Align search bar and order filter across full width of store page
- Default product listing to most recent items

## Testing
- `npm run lint` *(fails: Definition for rule 'valid-appcardcode-code-prop' was not found)*
- `npm run typecheck` *(fails: Cannot find module '@db/pages/profile/types' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fd614a14832fa8b95b5600da97af