### PR TITLE
Add negotiable offer flow

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/includes/acf-setup-purchases.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/acf-setup-purchases.php
@@ -186,4 +186,62 @@ acf_add_local_field_group(array(
     'description' => '',
 ));
 
+// Field group for "Oferta"
+acf_add_local_field_group(array(
+    'key' => 'group_ofertas',
+    'title' => 'Detalles de la Oferta',
+    'fields' => array(
+        array(
+            'key' => 'field_oferta_usuario',
+            'label' => 'Usuario',
+            'name' => 'usuario',
+            'type' => 'user',
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_oferta_motor',
+            'label' => 'Motor',
+            'name' => 'motor',
+            'type' => 'post_object',
+            'post_type' => array(
+                0 => 'motor',
+            ),
+            'allow_null' => 0,
+            'multiple' => 0,
+            'return_format' => 'object',
+            'ui' => 1,
+        ),
+        array(
+            'key' => 'field_oferta_monto',
+            'label' => 'Monto',
+            'name' => 'monto',
+            'type' => 'number',
+            'required' => 1,
+        ),
+        array(
+            'key' => 'field_oferta_justificacion',
+            'label' => 'Justificación',
+            'name' => 'justificacion',
+            'type' => 'textarea',
+        ),
+    ),
+    'location' => array(
+        array(
+            array(
+                'param' => 'post_type',
+                'operator' => '==',
+                'value' => 'oferta',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+));
+
 endif;

--- a/wp-content/plugins/motorlan-api-vue/includes/api/offers-routes.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/api/offers-routes.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * REST API routes for offers.
+ *
+ * @package motorlan-api-vue
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+function motorlan_register_offer_rest_routes() {
+    $namespace = 'motorlan/v1';
+
+    register_rest_route( $namespace, '/motors/(?P<motor_id>\d+)/offers', array(
+        array(
+            'methods'  => WP_REST_Server::READABLE,
+            'callback' => 'motorlan_get_offer_callback',
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ),
+        array(
+            'methods'  => WP_REST_Server::CREATABLE,
+            'callback' => 'motorlan_create_offer_callback',
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ),
+    ) );
+
+    register_rest_route( $namespace, '/offers/(?P<id>\d+)', array(
+        'methods'  => WP_REST_Server::DELETABLE,
+        'callback' => 'motorlan_delete_offer_callback',
+        'permission_callback' => function ( WP_REST_Request $request ) {
+            $offer_id = (int) $request['id'];
+            $author   = (int) get_field( 'usuario', $offer_id );
+            return get_current_user_id() === $author || current_user_can( 'delete_posts' );
+        },
+    ) );
+}
+add_action( 'rest_api_init', 'motorlan_register_offer_rest_routes' );
+
+function motorlan_get_offer_callback( WP_REST_Request $request ) {
+    $motor_id = (int) $request['motor_id'];
+    $user_id  = get_current_user_id();
+
+    $args = array(
+        'post_type'      => 'oferta',
+        'posts_per_page' => 1,
+        'meta_query'     => array(
+            array(
+                'key'   => 'motor',
+                'value' => $motor_id,
+            ),
+            array(
+                'key'   => 'usuario',
+                'value' => $user_id,
+            ),
+        ),
+    );
+
+    $query = new WP_Query( $args );
+    if ( $query->have_posts() ) {
+        $query->the_post();
+        $id  = get_the_ID();
+        $monto = get_field( 'monto', $id );
+        $just = get_field( 'justificacion', $id );
+        wp_reset_postdata();
+        return array(
+            'id'           => $id,
+            'monto'        => $monto,
+            'justificacion'=> $just,
+        );
+    }
+
+    return array();
+}
+
+function motorlan_create_offer_callback( WP_REST_Request $request ) {
+    $motor_id     = (int) $request['motor_id'];
+    $user_id      = get_current_user_id();
+    $monto        = floatval( $request->get_param( 'monto' ) );
+    $justificacion= sanitize_text_field( $request->get_param( 'justificacion' ) );
+
+    $existing = motorlan_get_offer_callback( $request );
+    if ( ! empty( $existing ) ) {
+        $offer_id = $existing['id'];
+    } else {
+        $offer_id = wp_insert_post( array(
+            'post_type'   => 'oferta',
+            'post_status' => 'publish',
+            'post_title'  => 'Oferta de ' . $user_id,
+        ) );
+    }
+
+    if ( is_wp_error( $offer_id ) ) {
+        return new WP_Error( 'cannot_create', 'Cannot create offer', array( 'status' => 500 ) );
+    }
+
+    update_field( 'usuario', $user_id, $offer_id );
+    update_field( 'motor', $motor_id, $offer_id );
+    update_field( 'monto', $monto, $offer_id );
+    update_field( 'justificacion', $justificacion, $offer_id );
+
+    return array(
+        'id'           => $offer_id,
+        'monto'        => $monto,
+        'justificacion'=> $justificacion,
+    );
+}
+
+function motorlan_delete_offer_callback( WP_REST_Request $request ) {
+    $offer_id = (int) $request['id'];
+    wp_delete_post( $offer_id, true );
+    return array( 'success' => true );
+}

--- a/wp-content/plugins/motorlan-api-vue/includes/cpt-setup-purchases.php
+++ b/wp-content/plugins/motorlan-api-vue/includes/cpt-setup-purchases.php
@@ -129,3 +129,43 @@ function motorlan_register_opinion_cpt() {
     register_post_type( 'opinion', $args );
 }
 add_action( 'init', 'motorlan_register_opinion_cpt' );
+
+/**
+ * Register a custom post type called "oferta".
+ */
+function motorlan_register_oferta_cpt() {
+    $labels = array(
+        'name'               => _x( 'Ofertas', 'post type general name', 'motorlan-api-vue' ),
+        'singular_name'      => _x( 'Oferta', 'post type singular name', 'motorlan-api-vue' ),
+        'menu_name'          => _x( 'Ofertas', 'admin menu', 'motorlan-api-vue' ),
+        'name_admin_bar'     => _x( 'Oferta', 'add new on admin bar', 'motorlan-api-vue' ),
+        'add_new'            => _x( 'Añadir Nueva', 'oferta', 'motorlan-api-vue' ),
+        'add_new_item'       => __( 'Añadir Nueva Oferta', 'motorlan-api-vue' ),
+        'new_item'           => __( 'Nueva Oferta', 'motorlan-api-vue' ),
+        'edit_item'          => __( 'Editar Oferta', 'motorlan-api-vue' ),
+        'view_item'          => __( 'Ver Oferta', 'motorlan-api-vue' ),
+        'all_items'          => __( 'Todas las Ofertas', 'motorlan-api-vue' ),
+        'search_items'       => __( 'Buscar Ofertas', 'motorlan-api-vue' ),
+        'not_found'          => __( 'No se encontraron ofertas.', 'motorlan-api-vue' ),
+        'not_found_in_trash' => __( 'No se encontraron ofertas en la papelera.', 'motorlan-api-vue' )
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'publicly_queryable' => true,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'query_var'          => true,
+        'rewrite'            => array( 'slug' => 'oferta' ),
+        'capability_type'    => 'post',
+        'has_archive'        => true,
+        'hierarchical'       => false,
+        'menu_position'      => 9,
+        'supports'           => array( 'title', 'editor', 'custom-fields' ),
+        'show_in_rest'       => true,
+    );
+
+    register_post_type( 'oferta', $args );
+}
+add_action( 'init', 'motorlan_register_oferta_cpt' );

--- a/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
+++ b/wp-content/plugins/motorlan-api-vue/motorlan-api-vue.php
@@ -29,6 +29,7 @@ require_once MOTORLAN_API_VUE_PATH . 'includes/api/motor-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/garantia-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/my-account-routes.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/api/questions-routes.php';
+require_once MOTORLAN_API_VUE_PATH . 'includes/api/offers-routes.php';
 
 require_once MOTORLAN_API_VUE_PATH . 'includes/admin-mods.php';
 require_once MOTORLAN_API_VUE_PATH . 'includes/vue-app-setup.php';


### PR DESCRIPTION
## Summary
- allow authenticated users to place, edit or remove offers on negotiable motors
- save offers via new `oferta` post type and REST API routes
- show description only when present and move purchase/offer buttons below it

## Testing
- `npm test` (missing script: "test")
- `npm run lint` (ENOENT: no such file or directory, scandir 'eslint-internal-rules')


------
https://chatgpt.com/codex/tasks/task_e_68a8ffbeda78832fb53d7635ee5212f2