### PR TITLE
Refactor CPTs to a single 'publicaciones' CPT

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/[slug].vue
@@ -3,10 +3,10 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import ProductImage from './components/ProductImage.vue'
 import ProductDetails from './components/ProductDetails.vue'
-import MotorInfo from './components/MotorInfo.vue'
+import PublicacionInfo from './components/PublicacionInfo.vue'
 import ProductDocs from './components/ProductDocs.vue'
 import RelatedProducts from './components/RelatedProducts.vue'
-import MotorQuestions from './components/MotorQuestions.vue'
+import PublicacionQuestions from './components/PublicacionQuestions.vue'
 import type { Publicacion } from '@/interfaces/publicacion'
 import { createUrl } from '@/@core/composable/createUrl'
 import { useApi } from '@/composables/useApi'
@@ -65,23 +65,23 @@ const title = computed(() => {
         cols="12"
         md="7"
       >
-        <ProductImage :motor="publicacion" />
+        <ProductImage :publicacion="publicacion" />
       </VCol>
       <VCol
         cols="12"
         md="5"
       >
-        <ProductDetails :motor="publicacion" />
+        <ProductDetails :publicacion="publicacion" />
       </VCol>
     </VRow>
 
     <div class="d-flex flex-wrap gap-6 my-8">
-      <MotorInfo :motor="publicacion" />
+      <PublicacionInfo :publicacion="publicacion" />
       <ProductDocs :docs="docs" />
     </div>
 
     <RelatedProducts :current-id="publicacion.id" />
-    <MotorQuestions :motor-id="publicacion.id" />
+    <PublicacionQuestions :publicacion-id="publicacion.id" />
   </VContainer>
 
   <div

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/tienda/components/ProductDetails.vue
@@ -117,7 +117,7 @@ const handlePurchase = async (confirmed: boolean) => {
   try {
     const res = await $api('/wp-json/motorlan/v1/purchases', {
       method: 'POST',
-      body: { motor_id: props.publicacion.id },
+      body: { publicacion_id: props.publicacion.id },
     })
     router.push(`/tienda/compra/${res.uuid}`)
   }


### PR DESCRIPTION
This commit refactors the custom post types `motor`, `regulador`, and `otro_repuesto` into a single CPT called `publicaciones`.

The changes include:
- A new `publicaciones` CPT that unifies the three old CPTs.
- A new `tipo` taxonomy to differentiate between "Motor", "Regulador", and "Otro Repuesto".
- The existing `categoria` and `marca` taxonomies are now associated with the new `publicaciones` CPT.
- The ACF field groups have been consolidated into a single group for `publicaciones`.
- The REST API routes have been updated to use `/publicaciones` instead of `/motors`.
- The Vue.js frontend has been updated to use the new API endpoints and data structure.

Note on frontend verification:
I was unable to build the Vue.js application due to issues with the `npm install` command in the provided environment. I have updated all the necessary files, but I could not verify that the frontend compiles and runs correctly. The user will need to run `npm install` and `npm run build` in the `wp-content/plugins/motorlan-api-vue/app` directory to build the frontend. I also had issues renaming directories, so the directory structure of the frontend is not yet updated.