### PR TITLE
Refactor CPTs to a single 'publicaciones' CPT

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/layouts/components/NavSearchBar.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/layouts/components/NavSearchBar.vue
@@ -32,7 +32,7 @@ const suggestionGroups: SuggestionGroup[] = [
   {
     title: 'Popular Searches',
     content: [
-      // { icon: 'tabler-car', title: 'Motors', url: { name: 'dashboards-motors' } }
+      // { icon: 'tabler-file-text', title: 'Publicaciones', url: { name: 'dashboards-publicaciones' } }
     ],
   },
 
@@ -60,9 +60,9 @@ const suggestionGroups: SuggestionGroup[] = [
 const noDataSuggestions: Suggestion[] = [
 
   {
-    title: 'Motors',
-    icon: 'tabler-car',
-    url: { name: 'dashboards-motors' },
+    title: 'Publicaciones',
+    icon: 'tabler-file-text',
+    url: { name: 'dashboards-publicaciones' },
   },
 ]
 

--- a/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/apps-and-pages.ts
@@ -6,11 +6,11 @@ export default [
   },
   { heading: 'Apps & Pages' },
   {
-    title: 'Motors',
-    icon: { icon: 'tabler-car' },
+    title: 'Publicaciones',
+    icon: { icon: 'tabler-file-text' },
     children: [
-      { title: 'List', to: 'apps-motors-motor-list' },
-      { title: 'Add', to: 'apps-motors-motor-add' },
+      { title: 'List', to: 'apps-publicaciones-publicacion-list' },
+      { title: 'Add', to: 'apps-publicaciones-publicacion-add' },
     ],
   },
   {

--- a/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/dashboard.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/navigation/vertical/dashboard.ts
@@ -5,7 +5,7 @@ export default [
     children: [
       {
         title: 'Ecommerce',
-        to: 'dashboards-motors',
+        to: 'dashboards-publicaciones',
       },
     ],
     badgeContent: '5',

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/login.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/login.vue
@@ -97,7 +97,7 @@ const login = async () => {
 
         router.replace(String(route.query.to))
       else
-        router.push({ name: 'dashboards-motors' })
+        router.push({ name: 'dashboards-publicaciones' })
     })
   }
   catch (err: any) {

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/1.router/additional-routes.ts
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/1.router/additional-routes.ts
@@ -13,7 +13,7 @@ export const redirects: RouteRecordRaw[] = [
       const userRole = userData.value?.role
 
       if (userRole === 'admin')
-        return { name: 'dashboards-motors' }
+        return { name: 'dashboards-publicaciones' }
 
       return { name: 'login', query: to.query }
     },

--- a/wp-content/plugins/motorlan-api-vue/app/src/views/front-pages/landing-page/hero-section.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/views/front-pages/landing-page/hero-section.vue
@@ -76,7 +76,7 @@ const translateMouse = computed(() => {
         <div class="blank-section" />
         <div class="hero-animation-img position-absolute">
           <RouterLink
-            :to="{ name: 'dashboards-motors' }"
+            :to="{ name: 'dashboards-publicaciones' }"
             target="_blank"
           >
             <div


### PR DESCRIPTION
This commit refactors the custom post types `motor`, `regulador`, and `otro_repuesto` into a single CPT called `publicaciones`.

The changes include:
- A new `publicaciones` CPT that unifies the three old CPTs.
- A new `tipo` taxonomy to differentiate between "Motor", "Regulador", and "Otro Repuesto".
- The existing `categoria` and `marca` taxonomies are now associated with the new `publicaciones` CPT.
- The ACF field groups have been consolidated into a single group for `publicaciones`.
- The REST API routes have been updated to use `/publicaciones` instead of `/motors`.
- The Vue.js frontend has been updated to use the new API endpoints and data structure.
- A routing issue in the frontend that was causing an infinite loading state has been fixed.

Note on frontend verification:
I was unable to build the Vue.js application due to issues with the `npm install` command in the provided environment. I have updated all the necessary files, but I could not verify that the frontend compiles and runs correctly. The user will need to run `npm install --legacy-peer-deps` and `npm run build` in the `wp-content/plugins/motorlan-api-vue/app` directory to build the frontend. I also had issues renaming directories, so the directory structure of the frontend is not yet updated.