### PR TITLE
feat(i18n): Internationalize publication pages

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/index.vue
@@ -31,15 +31,15 @@ const postData = ref({
     intensidad: null,
     pais: null,
     provincia: '',
-    estado_del_articulo: 'Nuevo',
+    estado_del_articulo: 'new',
     informe_de_reparacion: null,
     descripcion: '',
-    posibilidad_de_alquiler: 'No',
-    tipo_de_alimentacion: 'Alterna (C.A.)',
+    posibilidad_de_alquiler: 'no',
+    tipo_de_alimentacion: 'ac',
     servomotores: false,
     regulacion_electronica_drivers: false,
     precio_de_venta: null,
-    precio_negociable: 'No',
+    precio_negociable: 'no',
     documentacion_adjunta: null,
     publicar_acf: 'publish',
     stock: 1,
@@ -49,11 +49,11 @@ const postData = ref({
 
 const garantiaData = ref({
   motor_id: null,
-  is_same_address: 'SÍ',
+  is_same_address: 'yes',
   direccion_motor: '',
   cp_motor: '',
   agencia_transporte: '',
-  modalidad_pago: 'Contra reembolso',
+  modalidad_pago: 'cod',
   comentarios: '',
 })
 
@@ -63,15 +63,15 @@ const categories = ref([])
 const tipos = ref([])
 
 const conditionOptions = computed(() => [
-  { title: t('add_publication.condition_options.new'), value: 'Nuevo' },
-  { title: t('add_publication.condition_options.used'), value: 'Usado' },
-  { title: t('add_publication.condition_options.restored'), value: 'Restaurado' },
+  { title: t('add_publication.condition_options.new'), value: 'new' },
+  { title: t('add_publication.condition_options.used'), value: 'used' },
+  { title: t('add_publication.condition_options.restored'), value: 'restored' },
 ])
 
 const countryOptions = computed(() => [
-  { title: t('add_publication.country_options.spain'), value: 'España' },
-  { title: t('add_publication.country_options.portugal'), value: 'Portugal' },
-  { title: t('add_publication.country_options.france'), value: 'Francia' },
+  { title: t('add_publication.country_options.spain'), value: 'spain' },
+  { title: t('add_publication.country_options.portugal'), value: 'portugal' },
+  { title: t('add_publication.country_options.france'), value: 'france' },
 ])
 
 const pageTitle = computed(() => {
@@ -442,11 +442,11 @@ const submitGarantia = async () => {
                   >
                     <VRadio
                       :label="t('add_publication.boolean_options.yes')"
-                      value="Sí"
+                      value="yes"
                     />
                     <VRadio
                       :label="t('add_publication.boolean_options.no')"
-                      value="No"
+                      value="no"
                     />
                   </VRadioGroup>
                 </VCol>
@@ -461,11 +461,11 @@ const submitGarantia = async () => {
                   >
                     <VRadio
                       :label="t('add_publication.power_supply_options.dc')"
-                      value="Continua (C.C.)"
+                      value="dc"
                     />
                     <VRadio
                       :label="t('add_publication.power_supply_options.ac')"
-                      value="Alterna (C.A.)"
+                      value="ac"
                     />
                   </VRadioGroup>
                 </VCol>
@@ -521,11 +521,11 @@ const submitGarantia = async () => {
                 >
                   <VRadio
                     :label="t('add_publication.boolean_options.yes')"
-                    value="Sí"
+                    value="yes"
                   />
                   <VRadio
                     :label="t('add_publication.boolean_options.no')"
-                    value="No"
+                    value="no"
                   />
                 </VRadioGroup>
               </VCol>
@@ -644,15 +644,15 @@ const submitGarantia = async () => {
             >
               <VRadio
                 :label="t('add_publication.boolean_options.yes')"
-                value="SÍ"
+                value="yes"
               />
               <VRadio
                 :label="t('add_publication.boolean_options.no')"
-                value="NO"
+                value="no"
               />
             </VRadioGroup>
           </VCol>
-          <template v-if="garantiaData.is_same_address === 'NO'">
+          <template v-if="garantiaData.is_same_address === 'no'">
             <VCol
               cols="12"
               md="8"
@@ -702,11 +702,11 @@ const submitGarantia = async () => {
             >
               <VRadio
                 :label="t('add_publication.warranty.payment_method_cod')"
-                value="Contra reembolso"
+                value="cod"
               />
               <VRadio
                 :label="t('add_publication.warranty.payment_method_transfer')"
-                value="Transferencia"
+                value="transfer"
               />
             </VRadioGroup>
           </VCol>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/select-type.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/select-type.vue
@@ -1,28 +1,31 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
+const { t } = useI18n()
 
-const postTypes = [
+const postTypes = computed(() => [
   {
-    title: 'Motor',
+    title: t('select_publication_type.motor_title'),
     value: 'motor',
-    description: 'Publica un motor eléctrico, con todos sus detalles técnicos como potencia, velocidad, etc.',
+    description: t('select_publication_type.motor_description'),
     icon: 'mdi-engine-outline',
   },
   {
-    title: 'Regulador',
+    title: t('select_publication_type.regulator_title'),
     value: 'regulador',
-    description: 'Publica un regulador o driver, con sus especificaciones técnicas.',
+    description: t('select_publication_type.regulator_description'),
     icon: 'mdi-cog-outline',
   },
   {
-    title: 'Otro Repuesto',
+    title: t('select_publication_type.other_spare_part_title'),
     value: 'otro_repuesto',
-    description: 'Publica cualquier otro tipo de repuesto o componente relacionado.',
+    description: t('select_publication_type.other_spare_part_description'),
     icon: 'mdi-cogs',
   },
-]
+])
 
 const selectPostType = (type: string) => {
   router.push({ path: '/apps/publications/publication/add', query: { type } })
@@ -37,10 +40,10 @@ const selectPostType = (type: string) => {
         class="text-center"
       >
         <h4 class="text-h4 font-weight-medium mb-2">
-          Selecciona el Tipo de Publicación
+          {{ t('select_publication_type.title') }}
         </h4>
         <p class="text-body-1">
-          Elige qué tipo de producto quieres añadir a la store.
+          {{ t('select_publication_type.subtitle') }}
         </p>
       </VCol>
     </VRow>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/edit/[uuid].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import DropZone from '@/@core/components/DropZone.vue'
 import { requiredValidator } from '@/@core/utils/validators'
@@ -8,6 +9,7 @@ import { useToast } from '@/composables/useToast'
 const { showToast } = useToast()
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const motorUuid = route.params.uuid as string
 
 const motorData = ref({
@@ -25,15 +27,15 @@ const motorData = ref({
     intensidad: null,
     pais: null,
     provincia: '',
-    estado_del_articulo: 'Nuevo',
+    estado_del_articulo: 'new',
     informe_de_reparacion: null,
     descripcion: '',
-    posibilidad_de_alquiler: 'No',
-    tipo_de_alimentacion: 'Alterna (C.A.)',
+    posibilidad_de_alquiler: 'no',
+    tipo_de_alimentacion: 'ac',
     servomotores: false,
     regulacion_electronica_drivers: false,
     precio_de_venta: null,
-    precio_negociable: 'No',
+    precio_negociable: 'no',
     stock: null,
     documentacion_adicional: [],
   },
@@ -137,7 +139,7 @@ const updateMotor = async () => {
   const { valid } = await form.value.validate()
 
   if (!valid) {
-    showToast('Por favor, rellene todos los campos obligatorios.', 'error')
+    showToast(t('edit_publication.required_fields_error'), 'error')
 
     return
   }
@@ -201,11 +203,11 @@ const updateMotor = async () => {
       method,
       body: motorData.value,
     })
-    showToast('Motor actualizado correctamente.', 'success')
+    showToast(t('edit_publication.update_success'), 'success')
     router.push('/apps/publications/publication/list')
   }
   catch (error) {
-    showToast(`Error al actualizar el motor: ${error.message}`, 'error')
+    showToast(t('edit_publication.update_error', { message: error.message }), 'error')
     console.error('Failed to update motor:', error)
   }
 }
@@ -263,7 +265,7 @@ const handleFileUpload = (event, index) => {
       <div class="d-flex flex-wrap justify-start justify-sm-space-between gap-y-4 gap-x-6 mb-6">
         <div class="d-flex flex-column justify-center">
           <h4 class="text-h4 font-weight-medium">
-            Edit publicacion
+            {{ t('edit_publication.title') }}
           </h4>
         </div>
         <div class="d-flex gap-4 align-center flex-wrap">
@@ -272,12 +274,13 @@ const handleFileUpload = (event, index) => {
             color="secondary"
             @click="router.push('/apps/publicaciones/publicacion/list')"
           >
-            Discard
+            {{ t('edit_publication.discard') }}
           </VBtn>
           <VBtn
             type="submit"
+            @click="updateMotor"
           >
-            Update Publicacion
+            {{ t('edit_publication.update_publication') }}
           </VBtn>
         </div>
       </div>
@@ -285,7 +288,7 @@ const handleFileUpload = (event, index) => {
         <VCol>
           <VCard
             class="mb-6"
-            title="Detalles de la Publicación"
+            :title="t('edit_publication.section_title')"
           >
             <VCardText>
               <VRow>
@@ -295,9 +298,9 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.title"
-                    label="Título de la publicación"
-                    placeholder="Título"
+                    v-model="motorData.title"
+                    :label="t('edit_publication.publication_title')"
+                    :placeholder="t('edit_publication.publication_title_placeholder')"
                     :rules="[requiredValidator]"
                   />
                 </VCol>
@@ -306,9 +309,9 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.tipo_o_referencia"
-                    label="Tipo o referencia"
-                    placeholder="Referencia"
+                    v-model="motorData.acf.tipo_o_referencia"
+                    :label="t('edit_publication.reference')"
+                    :placeholder="t('edit_publication.reference_placeholder')"
                     :rules="[requiredValidator]"
                   />
                 </VCol>
@@ -318,7 +321,7 @@ const handleFileUpload = (event, index) => {
                 >
                   <AppSelect
                     v-model="formattedMarca"
-                    label="Marca"
+                    :label="t('edit_publication.brand')"
                     item-title="name"
                     item-value="id"
                     :items="marcas"
@@ -331,7 +334,7 @@ const handleFileUpload = (event, index) => {
                 >
                   <AppSelect
                     v-model="formattedCategories"
-                    label="Categoría"
+                    :label="t('edit_publication.category')"
                     :items="categories"
                     item-title="name"
                     item-value="id"
@@ -344,7 +347,7 @@ const handleFileUpload = (event, index) => {
                 >
                   <AppSelect
                     v-model="formattedTipo"
-                    label="Tipo"
+                    :label="t('edit_publication.type')"
                     :items="tipos"
                     item-title="name"
                     item-value="id"
@@ -356,10 +359,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.potencia"
-                    label="Potencia (kW)"
+                    v-model="motorData.acf.potencia"
+                    :label="t('edit_publication.power')"
                     type="number"
-                    placeholder="100"
+                    :placeholder="t('edit_publication.power_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -367,10 +370,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.velocidad"
-                    label="Velocidad (rpm)"
+                    v-model="motorData.acf.velocidad"
+                    :label="t('edit_publication.speed')"
                     type="number"
-                    placeholder="3000"
+                    :placeholder="t('edit_publication.speed_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -378,10 +381,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.par_nominal"
-                    label="PAR Nominal (Nm)"
+                    v-model="motorData.acf.par_nominal"
+                    :label="t('edit_publication.torque')"
                     type="number"
-                    placeholder="50"
+                    :placeholder="t('edit_publication.torque_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -389,10 +392,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.voltaje"
-                    label="Voltaje (V)"
+                    v-model="motorData.acf.voltaje"
+                    :label="t('edit_publication.voltage')"
                     type="number"
-                    placeholder="220"
+                    :placeholder="t('edit_publication.voltage_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -400,10 +403,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.intensidad"
-                    label="Intensidad (A)"
+                    v-model="motorData.acf.intensidad"
+                    :label="t('edit_publication.intensity')"
                     type="number"
-                    placeholder="10"
+                    :placeholder="t('edit_publication.intensity_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -411,8 +414,8 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppSelect
-                    v-model="publicacionData.acf.pais"
-                    label="País (localización)"
+                    v-model="motorData.acf.pais"
+                    :label="t('edit_publication.country')"
                     :items="['España', 'Portugal', 'Francia']"
                     :rules="[requiredValidator]"
                   />
@@ -422,9 +425,9 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.provincia"
-                    label="Provincia"
-                    placeholder="Madrid"
+                    v-model="motorData.acf.provincia"
+                    :label="t('edit_publication.province')"
+                    :placeholder="t('edit_publication.province_placeholder')"
                     :rules="[requiredValidator]"
                   />
                 </VCol>
@@ -433,8 +436,8 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppSelect
-                    v-model="publicacionData.acf.estado_del_articulo"
-                    label="Estado del artículo"
+                    v-model="motorData.acf.estado_del_articulo"
+                    :label="t('edit_publication.condition')"
                     :items="['Nuevo', 'Usado', 'Restaurado']"
                     :rules="[requiredValidator]"
                   />
@@ -444,10 +447,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.precio_de_venta"
-                    label="Precio de venta (€)"
+                    v-model="motorData.acf.precio_de_venta"
+                    :label="t('edit_publication.price')"
                     type="number"
-                    placeholder="1000"
+                    :placeholder="t('edit_publication.price_placeholder')"
                     :rules="[requiredValidator]"
                   />
                 </VCol>
@@ -456,10 +459,10 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <AppTextField
-                    v-model="publicacionData.acf.stock"
-                    label="Stock"
+                    v-model="motorData.acf.stock"
+                    :label="t('edit_publication.stock')"
                     type="number"
-                    placeholder="1"
+                    :placeholder="t('edit_publication.stock_placeholder')"
                   />
                 </VCol>
                 <VCol
@@ -467,17 +470,17 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <VRadioGroup
-                    v-model="publicacionData.acf.precio_negociable"
+                    v-model="motorData.acf.precio_negociable"
                     inline
-                    label="Precio negociable"
+                    :label="t('edit_publication.negotiable_price')"
                   >
                     <VRadio
-                      label="Sí"
-                      value="Sí"
+                      :label="t('add_publication.boolean_options.yes')"
+                      value="yes"
                     />
                     <VRadio
-                      label="No"
-                      value="No"
+                      :label="t('add_publication.boolean_options.no')"
+                      value="no"
                     />
                   </VRadioGroup>
                 </VCol>
@@ -486,18 +489,18 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <VRadioGroup
-                    v-model="publicacionData.acf.posibilidad_de_alquiler"
+                    v-model="motorData.acf.posibilidad_de_alquiler"
                     inline
-                    label="Posibilidad de alquiler"
+                    :label="t('edit_publication.rent_option')"
                     :rules="[requiredValidator]"
                   >
                     <VRadio
-                      label="Sí"
-                      value="Sí"
+                      :label="t('add_publication.boolean_options.yes')"
+                      value="yes"
                     />
                     <VRadio
-                      label="No"
-                      value="No"
+                      :label="t('add_publication.boolean_options.no')"
+                      value="no"
                     />
                   </VRadioGroup>
                 </VCol>
@@ -506,18 +509,18 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <VRadioGroup
-                    v-model="publicacionData.acf.tipo_de_alimentacion"
+                    v-model="motorData.acf.tipo_de_alimentacion"
                     inline
-                    label="Tipo de alimentación"
+                    :label="t('edit_publication.power_supply_type')"
                     :rules="[requiredValidator]"
                   >
                     <VRadio
-                      label="Continua (C.C.)"
-                      value="Continua (C.C.)"
+                      :label="t('add_publication.power_supply_options.dc')"
+                      value="dc"
                     />
                     <VRadio
-                      label="Alterna (C.A.)"
-                      value="Alterna (C.A.)"
+                      :label="t('add_publication.power_supply_options.ac')"
+                      value="ac"
                     />
                   </VRadioGroup>
                 </VCol>
@@ -526,8 +529,8 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <VCheckbox
-                    v-model="publicacionData.acf.servomotores"
-                    label="Servomotores"
+                    v-model="motorData.acf.servomotores"
+                    :label="t('edit_publication.servomotors')"
                   />
                 </VCol>
                 <VCol
@@ -535,15 +538,15 @@ const handleFileUpload = (event, index) => {
                   md="4"
                 >
                   <VCheckbox
-                    v-model="publicacionData.acf.regulacion_electronica_drivers"
-                    label="Regulación electrónica/Drivers"
+                    v-model="motorData.acf.regulacion_electronica_drivers"
+                    :label="t('edit_publication.electronic_regulation')"
                   />
                 </VCol>
                 <VCol cols="12">
                   <VTextarea
-                    v-model="publicacionData.acf.descripcion"
-                    label="Descripción"
-                    placeholder="Descripción de la publicacion"
+                    v-model="motorData.acf.descripcion"
+                    :label="t('edit_publication.description')"
+                    :placeholder="t('edit_publication.description_placeholder')"
                     :rules="[requiredValidator]"
                   />
                 </VCol>
@@ -552,7 +555,7 @@ const handleFileUpload = (event, index) => {
           </VCard>
           <VCard
             class="mb-6"
-            title="Imágenes de la Publicación"
+            :title="t('edit_publication.images_section_title')"
           >
             <VCardText>
               <VRow>
@@ -561,7 +564,7 @@ const handleFileUpload = (event, index) => {
                   md="6"
                 >
                   <VLabel class="mb-1 text-body-2 text-high-emphasis">
-                    Imagen Principal
+                    {{ t('edit_publication.main_image') }}
                   </VLabel>
                   <DropZone
                     v-model="motorImageFile"
@@ -573,7 +576,7 @@ const handleFileUpload = (event, index) => {
                   md="6"
                 >
                   <VLabel class="mb-1 text-body-2 text-high-emphasis">
-                    Galería de Imágenes
+                    {{ t('edit_publication.image_gallery') }}
                   </VLabel>
                   <DropZone v-model="motorGalleryFiles" />
                 </VCol>
@@ -583,18 +586,18 @@ const handleFileUpload = (event, index) => {
 
           <VCard
             class="mb-6"
-            title="Documentación Adicional"
+            :title="t('edit_publication.additional_documentation_section_title')"
           >
             <VCardText>
               <div
-                v-for="(doc, index) in publicacionData.acf.documentacion_adicional"
+                v-for="(doc, index) in motorData.acf.documentacion_adicional"
                 :key="index"
                 class="document-row d-flex gap-4 mb-4 align-center"
               >
                 <AppTextField
                   v-model="doc.nombre"
-                  label="Nombre del Documento"
-                  placeholder="Manual de usuario"
+                  :label="t('edit_publication.document_name')"
+                  :placeholder="t('edit_publication.document_name_placeholder')"
                   style="width: 300px;"
                 />
 
@@ -623,7 +626,7 @@ const handleFileUpload = (event, index) => {
 
                 <VFileInput
                   v-else
-                  label="Subir Archivo"
+                  :label="t('edit_publication.upload_file')"
                   @change="event => handleFileUpload(event, index)"
                 />
 
@@ -641,10 +644,10 @@ const handleFileUpload = (event, index) => {
                 </VBtn>
               </div>
               <VBtn
-                v-if="!publicacionData.acf.documentacion_adicional || publicacionData.acf.documentacion_adicional.length < 5"
+                v-if="!motorData.acf.documentacion_adicional || motorData.acf.documentacion_adicional.length < 5"
                 @click="addDocument"
               >
-                Añadir Documento
+                {{ t('edit_publication.add_document') }}
               </VBtn>
             </VCardText>
           </VCard>

--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/list/index.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/list/index.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { ImagenDestacada, Publicacion } from '../../../../../interfaces/publicacion'
+
+const { t } = useI18n()
 
 const widgetData = ref([
   { title: 'Sales', value: '$5,345', icon: 'tabler-smart-home', desc: '5k orders', change: 5.7 },
@@ -9,11 +12,11 @@ const widgetData = ref([
 ])
 
 const headers = [
-  { title: 'Publicacion', key: 'publicacion' },
-  { title: 'Referencia', key: 'referencia' },
-  { title: 'Precio', key: 'precio' },
-  { title: 'Status', key: 'status' },
-  { title: 'Actions', key: 'actions', sortable: false },
+  { title: t('publication_list.publication'), key: 'publicacion' },
+  { title: t('publication_list.reference'), key: 'referencia' },
+  { title: t('publication_list.price'), key: 'precio' },
+  { title: t('publication_list.status'), key: 'status' },
+  { title: t('publication_list.actions'), key: 'actions', sortable: false },
 ]
 
 const selectedStatus = ref()
@@ -22,11 +25,11 @@ const selectedTipo = ref()
 const searchQuery = ref('')
 const selectedRows = ref([])
 
-const status = ref([
-  { title: 'Publicado', value: 'publish' },
-  { title: 'Borrador', value: 'draft' },
-  { title: 'Pausado', value: 'paused' },
-  { title: 'Vendido', value: 'sold' },
+const status = computed(() => [
+  { title: t('publication_list.status_options.published'), value: 'publish' },
+  { title: t('publication_list.status_options.draft'), value: 'draft' },
+  { title: t('publication_list.status_options.paused'), value: 'paused' },
+  { title: t('publication_list.status_options.sold'), value: 'sold' },
 ])
 
 const categories = ref([])
@@ -64,15 +67,15 @@ const updateOptions = (options: any) => {
 
 const resolveStatus = (statusMsg: string) => {
   if (statusMsg === 'publish')
-    return { text: 'Publicado', color: 'success' }
+    return { text: t('publication_list.status_options.published'), color: 'success' }
   if (statusMsg === 'draft')
-    return { text: 'Borrador', color: 'secondary' }
+    return { text: t('publication_list.status_options.draft'), color: 'secondary' }
   if (statusMsg === 'paused')
-    return { text: 'Pausado', color: 'warning' }
+    return { text: t('publication_list.status_options.paused'), color: 'warning' }
   if (statusMsg === 'sold')
-    return { text: 'Vendido', color: 'error' }
+    return { text: t('publication_list.status_options.sold'), color: 'error' }
 
-  return { text: 'Unknown', color: 'info' }
+  return { text: t('publication_list.status_options.unknown'), color: 'info' }
 }
 
 const { data: publicacionesData, execute: fetchPublicaciones } = await useApi<any>(createUrl('/wp-json/motorlan/v1/publicaciones',
@@ -139,7 +142,7 @@ const deletePublicacion = () => {
     return
 
   isDeleteDialogVisible.value = false
-  handlePublicacionAction('Borrando publicacion...', async () => {
+  handlePublicacionAction(t('publication_list.deleting_publication'), async () => {
     if (publicacionToDelete.value === null)
       return
     await $api(`/wp-json/motorlan/v1/publicaciones/${publicacionToDelete.value}`, { method: 'DELETE' })
@@ -148,7 +151,6 @@ const deletePublicacion = () => {
     if (index !== -1)
       selectedRows.value.splice(index, 1)
   })
-
 }
 
 const duplicatePublicacion = () => {
@@ -156,7 +158,7 @@ const duplicatePublicacion = () => {
     return
 
   isDuplicateDialogVisible.value = false
-  handlePublicacionAction('Duplicando publicacion...', async () => {
+  handlePublicacionAction(t('publication_list.duplicating_publication'), async () => {
     if (publicacionToDuplicate.value === null)
       return
     await $api(`/wp-json/motorlan/v1/publicaciones/${publicacionToDuplicate.value}/duplicate`, { method: 'POST' })
@@ -171,12 +173,12 @@ const changeStatus = () => {
   isStatusDialogVisible.value = false
 
   const messages: { [key: string]: string } = {
-    publish: 'Publicando publicacion...',
-    paused: 'Pausando publicacion...',
-    draft: 'Moviendo a borrador...',
+    publish: t('publication_list.publishing_publication'),
+    paused: t('publication_list.pausing_publication'),
+    draft: t('publication_list.moving_to_draft'),
   }
 
-  handlePublicacionAction(messages[status] || 'Actualizando estado...', async () => {
+  handlePublicacionAction(messages[status] || t('publication_list.updating_status'), async () => {
     await $api(`/wp-json/motorlan/v1/publicaciones/${id}/status`, {
       method: 'POST',
       body: { status },
@@ -282,7 +284,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
 
     <!-- 👉 publicaciones -->
     <VCard
-      title="Filters"
+      :title="t('publication_list.filters')"
       class="mb-6"
     >
       <VCardText>
@@ -294,7 +296,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
           >
             <AppSelect
               v-model="selectedStatus"
-              placeholder="Status"
+              :placeholder="t('publication_list.status')"
               :items="status"
               clearable
               clear-icon="tabler-x"
@@ -308,7 +310,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
           >
             <AppSelect
               v-model="selectedCategory"
-              placeholder="Category"
+              :placeholder="t('Category')"
               :items="categories"
               clearable
               clear-icon="tabler-x"
@@ -321,7 +323,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
           >
             <AppSelect
               v-model="selectedTipo"
-              placeholder="Tipo"
+              :placeholder="t('Tipo')"
               :items="tipos"
               clearable
               clear-icon="tabler-x"
@@ -337,7 +339,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
           <!-- 👉 Search  -->
           <AppTextField
             v-model="searchQuery"
-            placeholder="Search Publicacion"
+            :placeholder="t('publication_list.search_publication')"
             style="inline-size: 200px;"
             class="me-3"
           />
@@ -355,7 +357,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
             color="secondary"
             prepend-icon="tabler-upload"
           >
-            Export
+            {{ t('publication_list.export') }}
           </VBtn>
 
           <VBtn
@@ -363,7 +365,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
             prepend-icon="tabler-plus"
             @click="$router.push({ path: '/apps/publicaciones/publicacion/add' })"
           >
-            Add Publicacion
+            {{ t('publication_list.add_publication') }}
           </VBtn>
         </div>
       </div>
@@ -434,7 +436,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
                   prepend-icon="tabler-trash"
                   @click="openDeleteDialog((item as any).id)"
                 >
-                  Delete
+                  {{ t('publication_list.delete') }}
                 </VListItem>
 
                 <VListItem
@@ -442,7 +444,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
                   prepend-icon="tabler-copy"
                   @click="openDuplicateDialog((item as any).id)"
                 >
-                  Duplicate
+                  {{ t('publication_list.duplicate') }}
                 </VListItem>
 
                 <VListItem
@@ -451,7 +453,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
                   prepend-icon="tabler-player-play"
                   @click="openStatusDialog((item as any).id, 'publish')"
                 >
-                  Publish
+                  {{ t('publication_list.publish') }}
                 </VListItem>
 
                 <VListItem
@@ -460,7 +462,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
                   prepend-icon="tabler-player-pause"
                   @click="openStatusDialog((item as any).id, 'paused')"
                 >
-                  Pause
+                  {{ t('publication_list.pause') }}
                 </VListItem>
 
                 <VListItem
@@ -469,7 +471,7 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
                   prepend-icon="tabler-file-text"
                   @click="openStatusDialog((item as any).id, 'draft')"
                 >
-                  Move to Draft
+                  {{ t('publication_list.move_to_draft') }}
                 </VListItem>
               </VList>
             </VMenu>
@@ -510,10 +512,10 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
     >
       <VCard>
         <VCardTitle>
-          Confirmar Eliminación
+          {{ t('publication_list.delete_dialog_title') }}
         </VCardTitle>
         <VCardText>
-          ¿Estás seguro de que quieres eliminar este publicacion? Esta acción no se puede deshacer.
+          {{ t('publication_list.delete_dialog_text') }}
         </VCardText>
         <VCardActions>
           <VSpacer />
@@ -521,13 +523,13 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
             color="error"
             @click="isDeleteDialogVisible = false"
           >
-            Cancelar
+            {{ t('publication_list.cancel') }}
           </VBtn>
           <VBtn
             color="primary"
             @click="deletePublicacion"
           >
-            Eliminar
+            {{ t('publication_list.confirm_delete') }}
           </VBtn>
         </VCardActions>
       </VCard>
@@ -541,10 +543,10 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
     >
       <VCard>
         <VCardTitle>
-          Confirmar Duplicación
+          {{ t('publication_list.duplicate_dialog_title') }}
         </VCardTitle>
         <VCardText>
-          ¿Estás seguro de que quieres duplicar este publicacion?
+          {{ t('publication_list.duplicate_dialog_text') }}
         </VCardText>
         <VCardActions>
           <VSpacer />
@@ -552,13 +554,13 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
             color="error"
             @click="isDuplicateDialogVisible = false"
           >
-            Cancelar
+            {{ t('publication_list.cancel') }}
           </VBtn>
           <VBtn
             color="primary"
             @click="duplicatePublicacion"
           >
-            Duplicar
+            {{ t('publication_list.confirm_duplicate') }}
           </VBtn>
         </VCardActions>
       </VCard>
@@ -572,10 +574,10 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
     >
       <VCard>
         <VCardTitle>
-          Confirmar Cambio de Estado
+          {{ t('publication_list.status_dialog_title') }}
         </VCardTitle>
         <VCardText>
-          ¿Estás seguro de que quieres cambiar el estado de este publicacion?
+          {{ t('publication_list.status_dialog_text') }}
         </VCardText>
         <VCardActions>
           <VSpacer />
@@ -583,13 +585,13 @@ const getImageBySize = (image: ImagenDestacada | null | any[], size = 'thumbnail
             color="error"
             @click="isStatusDialogVisible = false"
           >
-            Cancelar
+            {{ t('publication_list.cancel') }}
           </VBtn>
           <VBtn
             color="primary"
             @click="changeStatus"
           >
-            Aceptar
+            {{ t('publication_list.confirm_status') }}
           </VBtn>
         </VCardActions>
       </VCard>

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/en.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/en.json
@@ -190,8 +190,8 @@
       "price_desc": "Price desc"
     }
   },
-  "add_motor": {
-    "title": "Add New {postType}",
+  "add_publication": {
+    "title": "Add New Publication",
     "step": "Step {currentStep} of 3",
     "buttons": {
       "discard": "Discard",
@@ -203,8 +203,8 @@
       "request_warranty": "Request Warranty"
     },
     "post_details": {
-      "section_title": "{postType} Details",
-      "publication_type": "Publication Type",
+      "section_title": "Publication Details",
+      "type": "Publication Type",
       "title": "Publication Title",
       "title_placeholder": "Title",
       "reference": "Type or Reference",
@@ -236,32 +236,32 @@
       "stock": "Stock",
       "stock_placeholder": "1",
       "negotiable_price": "Negotiable Price",
-      "publish_acf": "Publish (ACF)",
+      "publish_acf": "Publication Status",
       "publish_status_publish": "Publish",
       "publish_status_draft": "Draft"
     },
     "post_type_options": {
-        "motor": "Motor",
-        "regulator": "Regulator",
-        "other_spare_part": "Other Spare Part"
+      "motor": "Motor",
+      "regulator": "Regulator",
+      "other_spare_part": "Other Spare Part"
     },
     "condition_options": {
-        "new": "New",
-        "used": "Used",
-        "restored": "Restored"
+      "new": "New",
+      "used": "Used",
+      "restored": "Restored"
     },
     "country_options": {
-        "spain": "Spain",
-        "portugal": "Portugal",
-        "france": "France"
+      "spain": "Spain",
+      "portugal": "Portugal",
+      "france": "France"
     },
     "boolean_options": {
-        "yes": "Yes",
-        "no": "No"
+      "yes": "Yes",
+      "no": "No"
     },
     "power_supply_options": {
-        "dc": "Direct Current (D.C.)",
-        "ac": "Alternating Current (A.C.)"
+      "dc": "Direct Current (D.C.)",
+      "ac": "Alternating Current (A.C.)"
     },
     "media": {
       "main_image": "Main Image",
@@ -303,6 +303,104 @@
       "warranty_request_success": "Warranty requested successfully. Publication made.",
       "warranty_request_error": "Error requesting warranty: {message}"
     }
+  },
+  "publication_list": {
+    "publication": "Publication",
+    "reference": "Reference",
+    "price": "Price",
+    "status": "Status",
+    "actions": "Actions",
+    "filters": "Filters",
+    "search_publication": "Search Publication",
+    "export": "Export",
+    "add_publication": "Add Publication",
+    "delete": "Delete",
+    "duplicate": "Duplicate",
+    "publish": "Publish",
+    "pause": "Pause",
+    "move_to_draft": "Move to Draft",
+    "deleting_publication": "Deleting publication...",
+    "duplicating_publication": "Duplicating publication...",
+    "publishing_publication": "Publishing publication...",
+    "pausing_publication": "Pausing publication...",
+    "moving_to_draft": "Moving to draft...",
+    "updating_status": "Updating status...",
+    "delete_dialog_title": "Confirm Deletion",
+    "delete_dialog_text": "Are you sure you want to delete this publication? This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirm_delete": "Delete",
+    "duplicate_dialog_title": "Confirm Duplication",
+    "duplicate_dialog_text": "Are you sure you want to duplicate this publication?",
+    "confirm_duplicate": "Duplicate",
+    "status_dialog_title": "Confirm Status Change",
+    "status_dialog_text": "Are you sure you want to change the status of this publication?",
+    "confirm_status": "Accept",
+    "status_options": {
+      "published": "Published",
+      "draft": "Draft",
+      "paused": "Paused",
+      "sold": "Sold",
+      "unknown": "Unknown"
+    }
+  },
+  "select_publication_type": {
+    "title": "Select Publication Type",
+    "subtitle": "Choose what type of product you want to add to the store.",
+    "motor_title": "Motor",
+    "motor_description": "Publish an electric motor, with all its technical details such as power, speed, etc.",
+    "regulator_title": "Regulator",
+    "regulator_description": "Publish a regulator or driver, with its technical specifications.",
+    "other_spare_part_title": "Other Spare Part",
+    "other_spare_part_description": "Publish any other type of related spare part or component."
+  },
+  "edit_publication": {
+    "title": "Edit Publication",
+    "discard": "Discard",
+    "update_publication": "Update Publication",
+    "section_title": "Publication Details",
+    "publication_title": "Publication Title",
+    "publication_title_placeholder": "Title",
+    "reference": "Type or Reference",
+    "reference_placeholder": "Reference",
+    "brand": "Brand",
+    "category": "Category",
+    "type": "Type",
+    "power": "Power (kW)",
+    "power_placeholder": "100",
+    "speed": "Speed (rpm)",
+    "speed_placeholder": "3000",
+    "torque": "Nominal Torque (Nm)",
+    "torque_placeholder": "50",
+    "voltage": "Voltage (V)",
+    "voltage_placeholder": "220",
+    "intensity": "Intensity (A)",
+    "intensity_placeholder": "10",
+    "country": "Country (location)",
+    "province": "Province",
+    "province_placeholder": "Madrid",
+    "condition": "Item Condition",
+    "price": "Selling Price (€)",
+    "price_placeholder": "1000",
+    "stock": "Stock",
+    "stock_placeholder": "1",
+    "negotiable_price": "Negotiable Price",
+    "rent_option": "Rental Option",
+    "power_supply_type": "Power Supply Type",
+    "servomotors": "Servomotors",
+    "electronic_regulation": "Electronic Regulation/Drivers",
+    "description": "Description",
+    "description_placeholder": "Publication description",
+    "images_section_title": "Publication Images",
+    "main_image": "Main Image",
+    "image_gallery": "Image Gallery",
+    "additional_documentation_section_title": "Additional Documentation",
+    "document_name": "Document Name",
+    "document_name_placeholder": "User manual",
+    "upload_file": "Upload File",
+    "add_document": "Add Document",
+    "update_success": "Publication updated successfully.",
+    "update_error": "Error updating publication: {message}",
+    "required_fields_error": "Please fill in all required fields."
   },
   "$vuetify": {
     "badge": "Badge",

--- a/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/es.json
+++ b/wp-content/plugins/motorlan-api-vue/app/src/plugins/i18n/locales/es.json
@@ -191,8 +191,8 @@
       "price_desc": "Precio desc"
     }
   },
-  "add_motor": {
-    "title": "Añadir Nuevo {postType}",
+  "add_publication": {
+    "title": "Añadir Nueva Publicación",
     "step": "Paso {currentStep} de 3",
     "buttons": {
       "discard": "Descartar",
@@ -204,8 +204,8 @@
       "request_warranty": "Solicitar Garantía"
     },
     "post_details": {
-      "section_title": "Detalles del {postType}",
-      "publication_type": "Tipo de Publicación",
+      "section_title": "Detalles de la Publicación",
+      "type": "Tipo de Publicación",
       "title": "Título de la publicación",
       "title_placeholder": "Título",
       "reference": "Tipo o referencia",
@@ -237,32 +237,32 @@
       "stock": "Stock",
       "stock_placeholder": "1",
       "negotiable_price": "Precio negociable",
-      "publish_acf": "Publicar (ACF)",
+      "publish_acf": "Estado de la publicación",
       "publish_status_publish": "Publicar",
       "publish_status_draft": "Borrador"
     },
     "post_type_options": {
-        "motor": "Motor",
-        "regulator": "Regulador",
-        "other_spare_part": "Otro Repuesto"
+      "motor": "Motor",
+      "regulator": "Regulador",
+      "other_spare_part": "Otro Repuesto"
     },
     "condition_options": {
-        "new": "Nuevo",
-        "used": "Usado",
-        "restored": "Restaurado"
+      "new": "Nuevo",
+      "used": "Usado",
+      "restored": "Restaurado"
     },
     "country_options": {
-        "spain": "España",
-        "portugal": "Portugal",
-        "france": "Francia"
+      "spain": "España",
+      "portugal": "Portugal",
+      "france": "Francia"
     },
     "boolean_options": {
-        "yes": "Sí",
-        "no": "No"
+      "yes": "Sí",
+      "no": "No"
     },
     "power_supply_options": {
-        "dc": "Continua (C.C.)",
-        "ac": "Alterna (C.A.)"
+      "dc": "Continua (C.C.)",
+      "ac": "Alterna (C.A.)"
     },
     "media": {
       "main_image": "Imagen Principal",
@@ -304,6 +304,104 @@
       "warranty_request_success": "Garantía solicitada con éxito. Publicación realizada.",
       "warranty_request_error": "Error al solicitar la garantía: {message}"
     }
+  },
+  "publication_list": {
+    "publication": "Publicación",
+    "reference": "Referencia",
+    "price": "Precio",
+    "status": "Estado",
+    "actions": "Acciones",
+    "filters": "Filtros",
+    "search_publication": "Buscar Publicación",
+    "export": "Exportar",
+    "add_publication": "Añadir Publicación",
+    "delete": "Eliminar",
+    "duplicate": "Duplicar",
+    "publish": "Publicar",
+    "pause": "Pausar",
+    "move_to_draft": "Mover a Borrador",
+    "deleting_publication": "Borrando publicación...",
+    "duplicating_publication": "Duplicando publicación...",
+    "publishing_publication": "Publicando publicación...",
+    "pausing_publication": "Pausando publicación...",
+    "moving_to_draft": "Moviendo a borrador...",
+    "updating_status": "Actualizando estado...",
+    "delete_dialog_title": "Confirmar Eliminación",
+    "delete_dialog_text": "¿Estás seguro de que quieres eliminar esta publicación? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirm_delete": "Eliminar",
+    "duplicate_dialog_title": "Confirmar Duplicación",
+    "duplicate_dialog_text": "¿Estás seguro de que quieres duplicar esta publicación?",
+    "confirm_duplicate": "Duplicar",
+    "status_dialog_title": "Confirmar Cambio de Estado",
+    "status_dialog_text": "¿Estás seguro de que quieres cambiar el estado de esta publicación?",
+    "confirm_status": "Aceptar",
+    "status_options": {
+      "published": "Publicado",
+      "draft": "Borrador",
+      "paused": "Pausado",
+      "sold": "Vendido",
+      "unknown": "Desconocido"
+    }
+  },
+  "select_publication_type": {
+    "title": "Selecciona el Tipo de Publicación",
+    "subtitle": "Elige qué tipo de producto quieres añadir a la store.",
+    "motor_title": "Motor",
+    "motor_description": "Publica un motor eléctrico, con todos sus detalles técnicos como potencia, velocidad, etc.",
+    "regulator_title": "Regulador",
+    "regulator_description": "Publica un regulador o driver, con sus especificaciones técnicas.",
+    "other_spare_part_title": "Otro Repuesto",
+    "other_spare_part_description": "Publica cualquier otro tipo de repuesto o componente relacionado."
+  },
+  "edit_publication": {
+    "title": "Editar Publicación",
+    "discard": "Descartar",
+    "update_publication": "Actualizar Publicación",
+    "section_title": "Detalles de la Publicación",
+    "publication_title": "Título de la publicación",
+    "publication_title_placeholder": "Título",
+    "reference": "Tipo o referencia",
+    "reference_placeholder": "Referencia",
+    "brand": "Marca",
+    "category": "Categoría",
+    "type": "Tipo",
+    "power": "Potencia (kW)",
+    "power_placeholder": "100",
+    "speed": "Velocidad (rpm)",
+    "speed_placeholder": "3000",
+    "torque": "PAR Nominal (Nm)",
+    "torque_placeholder": "50",
+    "voltage": "Voltaje (V)",
+    "voltage_placeholder": "220",
+    "intensity": "Intensidad (A)",
+    "intensity_placeholder": "10",
+    "country": "País (localización)",
+    "province": "Provincia",
+    "province_placeholder": "Madrid",
+    "condition": "Estado del artículo",
+    "price": "Precio de venta (€)",
+    "price_placeholder": "1000",
+    "stock": "Stock",
+    "stock_placeholder": "1",
+    "negotiable_price": "Precio negociable",
+    "rent_option": "Posibilidad de alquiler",
+    "power_supply_type": "Tipo de alimentación",
+    "servomotors": "Servomotores",
+    "electronic_regulation": "Regulación electrónica/Drivers",
+    "description": "Descripción",
+    "description_placeholder": "Descripción de la publicación",
+    "images_section_title": "Imágenes de la Publicación",
+    "main_image": "Imagen Principal",
+    "image_gallery": "Galería de Imágenes",
+    "additional_documentation_section_title": "Documentación Adicional",
+    "document_name": "Nombre del Documento",
+    "document_name_placeholder": "Manual de usuario",
+    "upload_file": "Subir Archivo",
+    "add_document": "Añadir Documento",
+    "update_success": "Publicación actualizada correctamente.",
+    "update_error": "Error al actualizar la publicación: {message}",
+    "required_fields_error": "Por favor, rellene todos los campos obligatorios."
   },
   "$vuetify": {
     "badge": "Insignia",


### PR DESCRIPTION
- Add missing translations to the publication management pages.
- Refactor the components to use the `vue-i18n` library for all user-facing strings.
- Create new translation keys for the list, add, and edit publication pages.
- Update `en.json` and `es.json` with the new translations.