### PR TITLE
Feat: Display selected publication type in form title

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/form.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/form.vue
@@ -78,7 +78,14 @@ const countryOptions = computed(() => [
 ])
 
 const pageTitle = computed(() => {
-  return t('add_publication.title')
+  const baseTitle = t('add_publication.title')
+  if (publicationType.value && tipos.value.length) {
+    const selectedType = tipos.value.find((t: any) => t.slug === publicationType.value)
+    if (selectedType) {
+      return `${baseTitle}: ${selectedType.title}`
+    }
+  }
+  return baseTitle
 })
 
 const apiEndpoint = '/wp-json/wp/v2/publicaciones'


### PR DESCRIPTION
- Modifies the page title on the publication form to include the name of the selected publication type (e.g., 'Add Publication: Motor').
- This provides a clear visual confirmation to the user of their selection from the previous step.