### PR TITLE
Feat: Dynamically update VCard title based on publication type

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/form.vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/add/form.vue
@@ -88,6 +88,20 @@ const pageTitle = computed(() => {
   return baseTitle
 })
 
+const cardTitle = computed(() => {
+  const slug = publicationType.value
+  if (slug === 'motor') {
+    return t('add_publication.post_details.motor_section_title', 'Detalles del Motor')
+  }
+  if (slug === 'regulador') {
+    return t('add_publication.post_details.regulator_section_title', 'Detalles del Regulador')
+  }
+  if (slug === 'otro-repuesto') {
+    return t('add_publication.post_details.spare_part_section_title', 'Detalles del Repuesto')
+  }
+  return t('add_publication.post_details.section_title', 'Detalles de la Publicación')
+})
+
 const apiEndpoint = '/wp-json/wp/v2/publicaciones'
 
 // Fetch initial data for selects
@@ -301,7 +315,7 @@ const submitGarantia = async () => {
       <VCol>
         <VCard
           class="mb-6"
-          :title="t('add_publication.post_details.section_title')"
+          :title="cardTitle"
         >
           <VCardText>
             <VRow>


### PR DESCRIPTION
- The title of the 'Post Details' card now dynamically changes to reflect the selected publication type (e.g., 'Detalles del Motor', 'Detalles del Regulador').
- This provides a more specific and user-friendly interface.