### PR TITLE
fix(publications): Attach gallery images to post on edit

### DIFF
--- a/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/edit/[uuid].vue
+++ b/wp-content/plugins/motorlan-api-vue/app/src/pages/apps/publications/publication/edit/[uuid].vue
@@ -280,7 +280,7 @@ const updateMotor = async (status: string) => {
       const galleryIds: number[] = []
       for (const image of motorGalleryFiles.value) {
         if (image.file) {
-          const uploadedImageId = await uploadMedia(image.file)
+          const uploadedImageId = await uploadMedia(image.file, postId.value ?? undefined)
           if (uploadedImageId)
             galleryIds.push(uploadedImageId)
         } else if (image.id) {


### PR DESCRIPTION
When editing a publication, gallery images were being uploaded to the media library but not attached to the post.

This was because the `uploadMedia` function was called without the post ID for gallery images.

This commit passes the `postId` to the `uploadMedia` function for gallery images, ensuring they are correctly associated with the publication.